### PR TITLE
Avoid sharing state across end-to-end test executions

### DIFF
--- a/EssentialFeed/EssentialFeedAPIEndToEndTests/EssentialFeedAPIEndToEndTests.swift
+++ b/EssentialFeed/EssentialFeedAPIEndToEndTests/EssentialFeedAPIEndToEndTests.swift
@@ -32,7 +32,7 @@ class EssentialFeedAPIEndToEndTests: XCTestCase {
 	
 	private func getFeedResult(file: StaticString = #file, line: UInt = #line) -> LoadFeedResult? {
 		let testServerURL = URL(string: "https://essentialdeveloper.com/feed-case-study/test-api/feed")!
-		let client = URLSessionHTTPClient()
+		let client = URLSessionHTTPClient(session: URLSession(configuration: .ephemeral))
 		let loader = RemoteFeedLoader(url: testServerURL, client: client)
 		trackForMemoryLeaks(client, file: file, line: line)
 		trackForMemoryLeaks(loader, file: file, line: line)


### PR DESCRIPTION
Use ephemeral URL session configuration to avoid sharing state across test executions (in-disk cache artifacts).