### PR TITLE
Extract cache policy from controller type

### DIFF
--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		08C0880C21E4EED600ACFB30 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C0880B21E4EED600ACFB30 /* HTTPClient.swift */; };
 		08C0880E21E4EF2900ACFB30 /* FeedItemsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C0880D21E4EF2900ACFB30 /* FeedItemsMapper.swift */; };
 		08DDC13A21BEA99E00F490ED /* LoadFeedFromRemoteUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08DDC13921BEA99E00F490ED /* LoadFeedFromRemoteUseCaseTests.swift */; };
+		08E5941522523FCC00E2D213 /* FeedCachePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E5941422523FCC00E2D213 /* FeedCachePolicy.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -76,6 +77,7 @@
 		08C0880B21E4EED600ACFB30 /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
 		08C0880D21E4EF2900ACFB30 /* FeedItemsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedItemsMapper.swift; sourceTree = "<group>"; };
 		08DDC13921BEA99E00F490ED /* LoadFeedFromRemoteUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromRemoteUseCaseTests.swift; sourceTree = "<group>"; };
+		08E5941422523FCC00E2D213 /* FeedCachePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCachePolicy.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -200,6 +202,7 @@
 				089C40DB22170EC500DE552E /* LocalFeedLoader.swift */,
 				089C40DD22170F2300DE552E /* FeedStore.swift */,
 				08868939221DAA34007BC3E7 /* LocalFeedImage.swift */,
+				08E5941422523FCC00E2D213 /* FeedCachePolicy.swift */,
 			);
 			path = "Feed Cache";
 			sourceTree = "<group>";
@@ -366,6 +369,7 @@
 				08C0880E21E4EF2900ACFB30 /* FeedItemsMapper.swift in Sources */,
 				080EDF0E21B6DCB600813479 /* FeedLoader.swift in Sources */,
 				08868938221DAA01007BC3E7 /* RemoteFeedItem.swift in Sources */,
+				08E5941522523FCC00E2D213 /* FeedCachePolicy.swift in Sources */,
 				08B42EA421C3F09A00DDA349 /* RemoteFeedLoader.swift in Sources */,
 				0886893A221DAA34007BC3E7 /* LocalFeedImage.swift in Sources */,
 				089C40DE22170F2300DE552E /* FeedStore.swift in Sources */,

--- a/EssentialFeed/EssentialFeed/Feed Cache/FeedCachePolicy.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/FeedCachePolicy.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright © 2019 Essential Developer. All rights reserved.
+//
+
+import Foundation
+
+internal final class FeedCachePolicy {
+	private init() {}
+	
+	private static let calendar = Calendar(identifier: .gregorian)
+	
+	private static var maxCacheAgeInDays: Int {
+		return 7
+	}
+	
+	internal static func validate(_ timestamp: Date, against date: Date) -> Bool {
+		guard let maxCacheAge = calendar.date(byAdding: .day, value: maxCacheAgeInDays, to: timestamp) else {
+			return false
+		}
+		return date < maxCacheAge
+	}
+}

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -5,34 +5,28 @@
 import Foundation
 
 private final class FeedCachePolicy {
-	private let currentDate: () -> Date
 	private let calendar = Calendar(identifier: .gregorian)
-	
-	init(currentDate: @escaping () -> Date) {
-		self.currentDate = currentDate
-	}
 	
 	private var maxCacheAgeInDays: Int {
 		return 7
 	}
 	
-	func validate(_ timestamp: Date) -> Bool {
+	func validate(_ timestamp: Date, against date: Date) -> Bool {
 		guard let maxCacheAge = calendar.date(byAdding: .day, value: maxCacheAgeInDays, to: timestamp) else {
 			return false
 		}
-		return currentDate() < maxCacheAge
+		return date < maxCacheAge
 	}
 }
 
 public final class LocalFeedLoader {
 	private let store: FeedStore
 	private let currentDate: () -> Date
-	private let cachePolicy: FeedCachePolicy
+	private let cachePolicy = FeedCachePolicy()
 	
 	public init(store: FeedStore, currentDate: @escaping () -> Date) {
 		self.store = store
 		self.currentDate = currentDate
-		self.cachePolicy = FeedCachePolicy(currentDate: currentDate)
 	}
 }
 
@@ -71,7 +65,7 @@ extension LocalFeedLoader: FeedLoader {
 			case let .failure(error):
 				completion(.failure(error))
 
-			case let .found(feed, timestamp) where self.cachePolicy.validate(timestamp):
+			case let .found(feed, timestamp) where self.cachePolicy.validate(timestamp, against: self.currentDate()):
 				completion(.success(feed.toModels()))
 				
 			case .found, .empty:
@@ -90,7 +84,7 @@ extension LocalFeedLoader {
 			case .failure:
 				self.store.deleteCachedFeed { _ in }
 				
-			case let .found(_, timestamp) where !self.cachePolicy.validate(timestamp):
+			case let .found(_, timestamp) where !self.cachePolicy.validate(timestamp, against: self.currentDate()):
 				self.store.deleteCachedFeed { _ in }
 				
 			case .empty, .found: break

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -4,23 +4,6 @@
 
 import Foundation
 
-private final class FeedCachePolicy {
-	private init() {}
-	
-	private static let calendar = Calendar(identifier: .gregorian)
-	
-	private static var maxCacheAgeInDays: Int {
-		return 7
-	}
-	
-	static func validate(_ timestamp: Date, against date: Date) -> Bool {
-		guard let maxCacheAge = calendar.date(byAdding: .day, value: maxCacheAgeInDays, to: timestamp) else {
-			return false
-		}
-		return date < maxCacheAge
-	}
-}
-
 public final class LocalFeedLoader {
 	private let store: FeedStore
 	private let currentDate: () -> Date

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -5,13 +5,15 @@
 import Foundation
 
 private final class FeedCachePolicy {
-	private let calendar = Calendar(identifier: .gregorian)
+	private init() {}
 	
-	private var maxCacheAgeInDays: Int {
+	private static let calendar = Calendar(identifier: .gregorian)
+	
+	private static var maxCacheAgeInDays: Int {
 		return 7
 	}
 	
-	func validate(_ timestamp: Date, against date: Date) -> Bool {
+	static func validate(_ timestamp: Date, against date: Date) -> Bool {
 		guard let maxCacheAge = calendar.date(byAdding: .day, value: maxCacheAgeInDays, to: timestamp) else {
 			return false
 		}
@@ -22,7 +24,6 @@ private final class FeedCachePolicy {
 public final class LocalFeedLoader {
 	private let store: FeedStore
 	private let currentDate: () -> Date
-	private let cachePolicy = FeedCachePolicy()
 	
 	public init(store: FeedStore, currentDate: @escaping () -> Date) {
 		self.store = store
@@ -65,7 +66,7 @@ extension LocalFeedLoader: FeedLoader {
 			case let .failure(error):
 				completion(.failure(error))
 
-			case let .found(feed, timestamp) where self.cachePolicy.validate(timestamp, against: self.currentDate()):
+			case let .found(feed, timestamp) where FeedCachePolicy.validate(timestamp, against: self.currentDate()):
 				completion(.success(feed.toModels()))
 				
 			case .found, .empty:
@@ -84,7 +85,7 @@ extension LocalFeedLoader {
 			case .failure:
 				self.store.deleteCachedFeed { _ in }
 				
-			case let .found(_, timestamp) where !self.cachePolicy.validate(timestamp, against: self.currentDate()):
+			case let .found(_, timestamp) where !FeedCachePolicy.validate(timestamp, against: self.currentDate()):
 				self.store.deleteCachedFeed { _ in }
 				
 			case .empty, .found: break

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -4,13 +4,11 @@
 
 import Foundation
 
-public final class LocalFeedLoader {
-	private let store: FeedStore
+private final class FeedCachePolicy {
 	private let currentDate: () -> Date
 	private let calendar = Calendar(identifier: .gregorian)
 	
-	public init(store: FeedStore, currentDate: @escaping () -> Date) {
-		self.store = store
+	init(currentDate: @escaping () -> Date) {
 		self.currentDate = currentDate
 	}
 	
@@ -18,11 +16,23 @@ public final class LocalFeedLoader {
 		return 7
 	}
 	
-	private func validate(_ timestamp: Date) -> Bool {
+	func validate(_ timestamp: Date) -> Bool {
 		guard let maxCacheAge = calendar.date(byAdding: .day, value: maxCacheAgeInDays, to: timestamp) else {
 			return false
 		}
 		return currentDate() < maxCacheAge
+	}
+}
+
+public final class LocalFeedLoader {
+	private let store: FeedStore
+	private let currentDate: () -> Date
+	private let cachePolicy: FeedCachePolicy
+	
+	public init(store: FeedStore, currentDate: @escaping () -> Date) {
+		self.store = store
+		self.currentDate = currentDate
+		self.cachePolicy = FeedCachePolicy(currentDate: currentDate)
 	}
 }
 
@@ -61,7 +71,7 @@ extension LocalFeedLoader: FeedLoader {
 			case let .failure(error):
 				completion(.failure(error))
 
-			case let .found(feed, timestamp) where self.validate(timestamp):
+			case let .found(feed, timestamp) where self.cachePolicy.validate(timestamp):
 				completion(.success(feed.toModels()))
 				
 			case .found, .empty:
@@ -80,7 +90,7 @@ extension LocalFeedLoader {
 			case .failure:
 				self.store.deleteCachedFeed { _ in }
 				
-			case let .found(_, timestamp) where !self.validate(timestamp):
+			case let .found(_, timestamp) where !self.cachePolicy.validate(timestamp):
 				self.store.deleteCachedFeed { _ in }
 				
 			case .empty, .found: break

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/Helpers/FeedCacheTestHelpers.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/Helpers/FeedCacheTestHelpers.swift
@@ -24,10 +24,12 @@ extension Date {
 		return 7
 	}
 	
-	func adding(days: Int) -> Date {
+	private func adding(days: Int) -> Date {
 		return Calendar(identifier: .gregorian).date(byAdding: .day, value: days, to: self)!
 	}
-	
+}
+
+extension Date {
 	func adding(seconds: TimeInterval) -> Date {
 		return self + seconds
 	}

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/Helpers/FeedCacheTestHelpers.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/Helpers/FeedCacheTestHelpers.swift
@@ -16,6 +16,10 @@ func uniqueImageFeed() -> (models: [FeedImage], local: [LocalFeedImage]) {
 }
 
 extension Date {
+	func minusFeedCacheMaxAge() -> Date {
+		return adding(days: -7)
+	}
+	
 	func adding(days: Int) -> Date {
 		return Calendar(identifier: .gregorian).date(byAdding: .day, value: days, to: self)!
 	}

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/Helpers/FeedCacheTestHelpers.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/Helpers/FeedCacheTestHelpers.swift
@@ -17,7 +17,11 @@ func uniqueImageFeed() -> (models: [FeedImage], local: [LocalFeedImage]) {
 
 extension Date {
 	func minusFeedCacheMaxAge() -> Date {
-		return adding(days: -7)
+		return adding(days: -feedCacheMaxAgeInDays)
+	}
+	
+	private var feedCacheMaxAgeInDays: Int {
+		return 7
 	}
 	
 	func adding(days: Int) -> Date {

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/LoadFeedFromCacheUseCaseTests.swift
@@ -38,36 +38,36 @@ class LoadFeedFromCacheUseCaseTests: XCTestCase {
 		})
 	}
 	
-	func test_load_deliversCachedImagesOnLessThanSevenDaysOldCache() {
+	func test_load_deliversCachedImagesOnNonExpiredCache() {
 		let feed = uniqueImageFeed()
 		let fixedCurrentDate = Date()
-		let lessThanSevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: 1)
+		let nonExpiredTimestamp = fixedCurrentDate.minusFeedCacheMaxAge().adding(seconds: 1)
 		let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
 		
 		expect(sut, toCompleteWith: .success(feed.models), when: {
-			store.completeRetrieval(with: feed.local, timestamp: lessThanSevenDaysOldTimestamp)
+			store.completeRetrieval(with: feed.local, timestamp: nonExpiredTimestamp)
 		})
 	}
 	
-	func test_load_deliversNoImagesOnSevenDaysOldCache() {
+	func test_load_deliversNoImagesOnCacheExpiration() {
 		let feed = uniqueImageFeed()
 		let fixedCurrentDate = Date()
-		let sevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7)
+		let expirationTimestamp = fixedCurrentDate.minusFeedCacheMaxAge()
 		let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
 		
 		expect(sut, toCompleteWith: .success([]), when: {
-			store.completeRetrieval(with: feed.local, timestamp: sevenDaysOldTimestamp)
+			store.completeRetrieval(with: feed.local, timestamp: expirationTimestamp)
 		})
 	}
 	
-	func test_load_deliversNoImagesOnMoreThanSevenDaysOldCache() {
+	func test_load_deliversNoImagesOnExpiredCache() {
 		let feed = uniqueImageFeed()
 		let fixedCurrentDate = Date()
-		let moreThanSevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: -1)
+		let expiredTimestamp = fixedCurrentDate.minusFeedCacheMaxAge().adding(seconds: -1)
 		let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
 		
 		expect(sut, toCompleteWith: .success([]), when: {
-			store.completeRetrieval(with: feed.local, timestamp: moreThanSevenDaysOldTimestamp)
+			store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
 		})
 	}
 	
@@ -89,38 +89,38 @@ class LoadFeedFromCacheUseCaseTests: XCTestCase {
 		XCTAssertEqual(store.receivedMessages, [.retrieve])
 	}
 	
-	func test_load_hasNoSideEffectsOnLessThanSevenDaysOldCache() {
+	func test_load_hasNoSideEffectsOnNonExpiredCache() {
 		let feed = uniqueImageFeed()
 		let fixedCurrentDate = Date()
-		let lessThanSevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: 1)
+		let nonExpiredTimestamp = fixedCurrentDate.minusFeedCacheMaxAge().adding(seconds: 1)
 		let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
 
 		sut.load { _ in }
-		store.completeRetrieval(with: feed.local, timestamp: lessThanSevenDaysOldTimestamp)
+		store.completeRetrieval(with: feed.local, timestamp: nonExpiredTimestamp)
 		
 		XCTAssertEqual(store.receivedMessages, [.retrieve])
 	}
 	
-	func test_load_hasNoSideEffectsOnSevenDaysOldCache() {
+	func test_load_hasNoSideEffectsOnCacheExpiration() {
 		let feed = uniqueImageFeed()
 		let fixedCurrentDate = Date()
-		let sevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7)
+		let expirationTimestamp = fixedCurrentDate.minusFeedCacheMaxAge()
 		let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
 		
 		sut.load { _ in }
-		store.completeRetrieval(with: feed.local, timestamp: sevenDaysOldTimestamp)
+		store.completeRetrieval(with: feed.local, timestamp: expirationTimestamp)
 		
 		XCTAssertEqual(store.receivedMessages, [.retrieve])
 	}
 	
-	func test_load_hasNoSideEffectsOnMoreThanSevenDaysOldCache() {
+	func test_load_hasNoSideEffectsOnExpiredCache() {
 		let feed = uniqueImageFeed()
 		let fixedCurrentDate = Date()
-		let moreThanSevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: -1)
+		let expiredTimestamp = fixedCurrentDate.minusFeedCacheMaxAge().adding(seconds: -1)
 		let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
 		
 		sut.load { _ in }
-		store.completeRetrieval(with: feed.local, timestamp: moreThanSevenDaysOldTimestamp)
+		store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
 		
 		XCTAssertEqual(store.receivedMessages, [.retrieve])
 	}

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/ValidateFeedCacheUseCaseTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/ValidateFeedCacheUseCaseTests.swift
@@ -31,38 +31,38 @@ class ValidateFeedCacheUseCaseTests: XCTestCase {
 		XCTAssertEqual(store.receivedMessages, [.retrieve])
 	}
 	
-	func test_validateCache_doesNotDeleteLessThanSevenDaysOldCache() {
+	func test_validateCache_doesNotDeleteNonExpiredCache() {
 		let feed = uniqueImageFeed()
 		let fixedCurrentDate = Date()
-		let lessThanSevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: 1)
+		let nonExpiredTimestamp = fixedCurrentDate.minusFeedCacheMaxAge().adding(seconds: 1)
 		let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
 		
 		sut.validateCache()
-		store.completeRetrieval(with: feed.local, timestamp: lessThanSevenDaysOldTimestamp)
+		store.completeRetrieval(with: feed.local, timestamp: nonExpiredTimestamp)
 		
 		XCTAssertEqual(store.receivedMessages, [.retrieve])
 	}
 	
-	func test_validateCache_deletesSevenDaysOldCache() {
+	func test_validateCache_deletesCacheOnExpiration() {
 		let feed = uniqueImageFeed()
 		let fixedCurrentDate = Date()
-		let sevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7)
+		let expirationTimestamp = fixedCurrentDate.minusFeedCacheMaxAge()
 		let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
 		
 		sut.validateCache()
-		store.completeRetrieval(with: feed.local, timestamp: sevenDaysOldTimestamp)
+		store.completeRetrieval(with: feed.local, timestamp: expirationTimestamp)
 		
 		XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
 	}
 	
-	func test_validateCache_deletesMoreThanSevenDaysOldCache() {
+	func test_validateCache_deletesExpiredCache() {
 		let feed = uniqueImageFeed()
 		let fixedCurrentDate = Date()
-		let moreThanSevenDaysOldTimestamp = fixedCurrentDate.adding(days: -7).adding(seconds: -1)
+		let expiredTimestamp = fixedCurrentDate.minusFeedCacheMaxAge().adding(seconds: -1)
 		let (sut, store) = makeSUT(currentDate: { fixedCurrentDate })
 		
 		sut.validateCache()
-		store.completeRetrieval(with: feed.local, timestamp: moreThanSevenDaysOldTimestamp)
+		store.completeRetrieval(with: feed.local, timestamp: expiredTimestamp)
 		
 		XCTAssertEqual(store.receivedMessages, [.retrieve, .deleteCachedFeed])
 	}


### PR DESCRIPTION
• Extract cache policy from controller type (`LocalFeedLoader`) into the new `FeedCachePolicy`
• Hide the *7 days max age* detail from production and tests by making it a private concept within centralized/reusable methods (single source of truth).