### PR TITLE
CodableFeedStore partial implementation (retrieve and insert happy path)

### DIFF
--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		0845C25E22035FBD003C5EF1 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0844768E21FCB24E00439BE9 /* XCTestCase+MemoryLeakTracking.swift */; };
 		086BE481223270A3004CDC26 /* LoadFeedFromCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086BE480223270A3004CDC26 /* LoadFeedFromCacheUseCaseTests.swift */; };
 		086BE4842232725E004CDC26 /* FeedStoreSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086BE4832232725E004CDC26 /* FeedStoreSpy.swift */; };
+		08863F9A2264C89E0050A822 /* CodableFeedStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08863F992264C89E0050A822 /* CodableFeedStoreTests.swift */; };
 		08868938221DAA01007BC3E7 /* RemoteFeedItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08868937221DAA01007BC3E7 /* RemoteFeedItem.swift */; };
 		0886893A221DAA34007BC3E7 /* LocalFeedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08868939221DAA34007BC3E7 /* LocalFeedImage.swift */; };
 		0899395F220359C50031B03D /* EssentialFeedAPIEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0899395E220359C50031B03D /* EssentialFeedAPIEndToEndTests.swift */; };
@@ -65,6 +66,7 @@
 		0844769021FCBE7D00439BE9 /* URLSessionHTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionHTTPClient.swift; sourceTree = "<group>"; };
 		086BE480223270A3004CDC26 /* LoadFeedFromCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromCacheUseCaseTests.swift; sourceTree = "<group>"; };
 		086BE4832232725E004CDC26 /* FeedStoreSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedStoreSpy.swift; sourceTree = "<group>"; };
+		08863F992264C89E0050A822 /* CodableFeedStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableFeedStoreTests.swift; sourceTree = "<group>"; };
 		08868937221DAA01007BC3E7 /* RemoteFeedItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedItem.swift; sourceTree = "<group>"; };
 		08868939221DAA34007BC3E7 /* LocalFeedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFeedImage.swift; sourceTree = "<group>"; };
 		0899395C220359C50031B03D /* EssentialFeedAPIEndToEndTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialFeedAPIEndToEndTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -192,6 +194,7 @@
 				089C40D32216C37400DE552E /* CacheFeedUseCaseTests.swift */,
 				086BE480223270A3004CDC26 /* LoadFeedFromCacheUseCaseTests.swift */,
 				081C0DAE22491A2400AC754E /* ValidateFeedCacheUseCaseTests.swift */,
+				08863F992264C89E0050A822 /* CodableFeedStoreTests.swift */,
 			);
 			path = "Feed Cache";
 			sourceTree = "<group>";
@@ -384,6 +387,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				08863F9A2264C89E0050A822 /* CodableFeedStoreTests.swift in Sources */,
 				081C0DB122491E1200AC754E /* FeedCacheTestHelpers.swift in Sources */,
 				081C0DAF22491A2400AC754E /* ValidateFeedCacheUseCaseTests.swift in Sources */,
 				08DDC13A21BEA99E00F490ED /* LoadFeedFromRemoteUseCaseTests.swift in Sources */,

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedImage.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedImage.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct LocalFeedImage: Equatable, Codable {
+public struct LocalFeedImage: Equatable {
 	public let id: UUID
 	public let description: String?
 	public let location: String?

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedImage.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedImage.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct LocalFeedImage: Equatable {
+public struct LocalFeedImage: Equatable, Codable {
 	public let id: UUID
 	public let description: String?
 	public let location: String?

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -63,13 +63,13 @@ class CodableFeedStoreTests: XCTestCase {
 	override func setUp() {
 		super.setUp()
 		
-		try? FileManager.default.removeItem(at: storeURL())
+		try? FileManager.default.removeItem(at: testSpecificStoreURL())
 	}
 
 	override func tearDown() {
 		super.tearDown()
 		
-		try? FileManager.default.removeItem(at: storeURL())
+		try? FileManager.default.removeItem(at: testSpecificStoreURL())
 	}
 	
 	func test_retrieve_deliversEmptyOnEmptyCache() {
@@ -141,13 +141,13 @@ class CodableFeedStoreTests: XCTestCase {
 	// - MARK: Helpers
 	
 	private func makeSUT(file: StaticString = #file, line: UInt = #line) -> CodableFeedStore {
-		let sut = CodableFeedStore(storeURL: storeURL())
+		let sut = CodableFeedStore(storeURL: testSpecificStoreURL())
 		trackForMemoryLeaks(sut, file: file, line: line)
 		return sut
 	}
 	
-	private func storeURL() -> URL {
-		return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("image-feed.store")
+	private func testSpecificStoreURL() -> URL {
+		return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent("\(type(of: self)).store")
 	}
 	
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -33,7 +33,11 @@ class CodableFeedStore {
 		}
 	}
 	
-	private let storeURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("image-feed.store")
+	private let storeURL: URL
+	
+	init(storeURL: URL) {
+		self.storeURL = storeURL
+	}
 	
 	func retrieve(completion: @escaping FeedStore.RetrievalCompletion) {
 		guard let data = try? Data(contentsOf: storeURL) else {
@@ -139,7 +143,8 @@ class CodableFeedStoreTests: XCTestCase {
 	// - MARK: Helpers
 	
 	private func makeSUT(file: StaticString = #file, line: UInt = #line) -> CodableFeedStore {
-		let sut = CodableFeedStore()
+		let storeURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("image-feed.store")
+		let sut = CodableFeedStore(storeURL: storeURL)
 		trackForMemoryLeaks(sut, file: file, line: line)
 		return sut
 	}

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -7,8 +7,30 @@ import EssentialFeed
 
 class CodableFeedStore {
 	private struct Cache: Codable {
-		let feed: [LocalFeedImage]
+		let feed: [CodableFeedImage]
 		let timestamp: Date
+		
+		var localFeed: [LocalFeedImage] {
+			return feed.map { $0.local }
+		}
+	}
+	
+	private struct CodableFeedImage: Codable {
+		private let id: UUID
+		private let description: String?
+		private let location: String?
+		private let url: URL
+		
+		init(_ image: LocalFeedImage) {
+			id = image.id
+			description = image.description
+			location = image.location
+			url = image.url
+		}
+		
+		var local: LocalFeedImage {
+			return LocalFeedImage(id: id, description: description, location: location, url: url)
+		}
 	}
 	
 	private let storeURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("image-feed.store")
@@ -20,12 +42,13 @@ class CodableFeedStore {
 		
 		let decoder = JSONDecoder()
 		let cache = try! decoder.decode(Cache.self, from: data)
-		completion(.found(feed: cache.feed, timestamp: cache.timestamp))
+		completion(.found(feed: cache.localFeed, timestamp: cache.timestamp))
 	}
 	
 	func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping FeedStore.InsertionCompletion) {
 		let encoder = JSONEncoder()
-		let encoded = try! encoder.encode(Cache(feed: feed, timestamp: timestamp))
+		let cache = Cache(feed: feed.map(CodableFeedImage.init), timestamp: timestamp)
+		let encoded = try! encoder.encode(cache)
 		try! encoded.write(to: storeURL)
 		completion(nil)
 	}

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -63,15 +63,13 @@ class CodableFeedStoreTests: XCTestCase {
 	override func setUp() {
 		super.setUp()
 		
-		let storeURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("image-feed.store")
-		try? FileManager.default.removeItem(at: storeURL)
+		try? FileManager.default.removeItem(at: storeURL())
 	}
 
 	override func tearDown() {
 		super.tearDown()
 		
-		let storeURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("image-feed.store")
-		try? FileManager.default.removeItem(at: storeURL)
+		try? FileManager.default.removeItem(at: storeURL())
 	}
 	
 	func test_retrieve_deliversEmptyOnEmptyCache() {
@@ -143,10 +141,13 @@ class CodableFeedStoreTests: XCTestCase {
 	// - MARK: Helpers
 	
 	private func makeSUT(file: StaticString = #file, line: UInt = #line) -> CodableFeedStore {
-		let storeURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("image-feed.store")
-		let sut = CodableFeedStore(storeURL: storeURL)
+		let sut = CodableFeedStore(storeURL: storeURL())
 		trackForMemoryLeaks(sut, file: file, line: line)
 		return sut
+	}
+	
+	private func storeURL() -> URL {
+		return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("image-feed.store")
 	}
 	
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -71,7 +71,7 @@ class CodableFeedStoreTests: XCTestCase {
 	}
 	
 	func test_retrieve_deliversEmptyOnEmptyCache() {
-		let sut = CodableFeedStore()
+		let sut = makeSUT()
 		let exp = expectation(description: "Wait for cache retrieval")
 		
 		sut.retrieve { result in
@@ -90,7 +90,7 @@ class CodableFeedStoreTests: XCTestCase {
 	}
 	
 	func test_retrieve_hasNoSideEffectsOnEmptyCache() {
-		let sut = CodableFeedStore()
+		let sut = makeSUT()
 		let exp = expectation(description: "Wait for cache retrieval")
 		
 		sut.retrieve { firstResult in
@@ -111,7 +111,7 @@ class CodableFeedStoreTests: XCTestCase {
 	}
 	
 	func test_retrieveAfterInsertingToEmptyCache_deliversInsertedValues() {
-		let sut = CodableFeedStore()
+		let sut = makeSUT()
 		let feed = uniqueImageFeed().local
 		let timestamp = Date()
 		let exp = expectation(description: "Wait for cache retrieval")
@@ -134,6 +134,12 @@ class CodableFeedStoreTests: XCTestCase {
 		}
 		
 		wait(for: [exp], timeout: 1.0)
+	}
+	
+	// - MARK: Helpers
+	
+	private func makeSUT() -> CodableFeedStore {
+		return CodableFeedStore()
 	}
 	
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -6,12 +6,46 @@ import XCTest
 import EssentialFeed
 
 class CodableFeedStore {
+	private struct Cache: Codable {
+		let feed: [LocalFeedImage]
+		let timestamp: Date
+	}
+	
+	private let storeURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("image-feed.store")
+	
 	func retrieve(completion: @escaping FeedStore.RetrievalCompletion) {
-		completion(.empty)
+		guard let data = try? Data(contentsOf: storeURL) else {
+			return completion(.empty)
+		}
+		
+		let decoder = JSONDecoder()
+		let cache = try! decoder.decode(Cache.self, from: data)
+		completion(.found(feed: cache.feed, timestamp: cache.timestamp))
+	}
+	
+	func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping FeedStore.InsertionCompletion) {
+		let encoder = JSONEncoder()
+		let encoded = try! encoder.encode(Cache(feed: feed, timestamp: timestamp))
+		try! encoded.write(to: storeURL)
+		completion(nil)
 	}
 }
 
 class CodableFeedStoreTests: XCTestCase {
+	
+	override func setUp() {
+		super.setUp()
+		
+		let storeURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("image-feed.store")
+		try? FileManager.default.removeItem(at: storeURL)
+	}
+
+	override func tearDown() {
+		super.tearDown()
+		
+		let storeURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!.appendingPathComponent("image-feed.store")
+		try? FileManager.default.removeItem(at: storeURL)
+	}
 	
 	func test_retrieve_deliversEmptyOnEmptyCache() {
 		let sut = CodableFeedStore()
@@ -52,4 +86,31 @@ class CodableFeedStoreTests: XCTestCase {
 		
 		wait(for: [exp], timeout: 1.0)
 	}
+	
+	func test_retrieveAfterInsertingToEmptyCache_deliversInsertedValues() {
+		let sut = CodableFeedStore()
+		let feed = uniqueImageFeed().local
+		let timestamp = Date()
+		let exp = expectation(description: "Wait for cache retrieval")
+		
+		sut.insert(feed, timestamp: timestamp) { insertionError in
+			XCTAssertNil(insertionError, "Expected feed to be inserted successfully")
+			
+			sut.retrieve { retrieveResult in
+				switch retrieveResult {
+				case let .found(retrievedFeed, retrievedTimestamp):
+					XCTAssertEqual(retrievedFeed, feed)
+					XCTAssertEqual(retrievedTimestamp, timestamp)
+					
+				default:
+					XCTFail("Expected found result with feed \(feed) and timestamp \(timestamp), got \(retrieveResult) instead")
+				}
+				
+				exp.fulfill()
+			}
+		}
+		
+		wait(for: [exp], timeout: 1.0)
+	}
+	
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -1,0 +1,35 @@
+//
+//  Copyright © 2019 Essential Developer. All rights reserved.
+//
+
+import XCTest
+import EssentialFeed
+
+class CodableFeedStore {
+	func retrieve(completion: @escaping FeedStore.RetrievalCompletion) {
+		completion(.empty)
+	}
+}
+
+class CodableFeedStoreTests: XCTestCase {
+	
+	func test_retrieve_deliversEmptyOnEmptyCache() {
+		let sut = CodableFeedStore()
+		let exp = expectation(description: "Wait for cache retrieval")
+		
+		sut.retrieve { result in
+			switch result {
+			case .empty:
+				break
+				
+			default:
+				XCTFail("Expected empty result, got \(result) instead")
+			}
+			
+			exp.fulfill()
+		}
+		
+		wait(for: [exp], timeout: 1.0)
+	}
+	
+}

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -32,4 +32,24 @@ class CodableFeedStoreTests: XCTestCase {
 		wait(for: [exp], timeout: 1.0)
 	}
 	
+	func test_retrieve_hasNoSideEffectsOnEmptyCache() {
+		let sut = CodableFeedStore()
+		let exp = expectation(description: "Wait for cache retrieval")
+		
+		sut.retrieve { firstResult in
+			sut.retrieve { secondResult in
+				switch (firstResult, secondResult) {
+				case (.empty, .empty):
+					break
+					
+				default:
+					XCTFail("Expected retrieving twice from empty cache to deliver same empty result, got \(firstResult) and \(secondResult) instead")
+				}
+				
+				exp.fulfill()
+			}
+		}
+		
+		wait(for: [exp], timeout: 1.0)
+	}
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -138,8 +138,10 @@ class CodableFeedStoreTests: XCTestCase {
 	
 	// - MARK: Helpers
 	
-	private func makeSUT() -> CodableFeedStore {
-		return CodableFeedStore()
+	private func makeSUT(file: StaticString = #file, line: UInt = #line) -> CodableFeedStore {
+		let sut = CodableFeedStore()
+		trackForMemoryLeaks(sut, file: file, line: line)
+		return sut
 	}
 	
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -63,13 +63,13 @@ class CodableFeedStoreTests: XCTestCase {
 	override func setUp() {
 		super.setUp()
 		
-		try? FileManager.default.removeItem(at: testSpecificStoreURL())
+		setupEmptyStoreState()
 	}
-
+	
 	override func tearDown() {
 		super.tearDown()
 		
-		try? FileManager.default.removeItem(at: testSpecificStoreURL())
+		undoStoreSideEffects()
 	}
 	
 	func test_retrieve_deliversEmptyOnEmptyCache() {
@@ -144,6 +144,18 @@ class CodableFeedStoreTests: XCTestCase {
 		let sut = CodableFeedStore(storeURL: testSpecificStoreURL())
 		trackForMemoryLeaks(sut, file: file, line: line)
 		return sut
+	}
+	
+	private func setupEmptyStoreState() {
+		deleteStoreArtifacts()
+	}
+	
+	private func undoStoreSideEffects() {
+		deleteStoreArtifacts()
+	}
+	
+	private func deleteStoreArtifacts() {
+		try? FileManager.default.removeItem(at: testSpecificStoreURL())
 	}
 	
 	private func testSpecificStoreURL() -> URL {


### PR DESCRIPTION
- Retrieve
	✅ Empty cache returns empty
	✅ Empty cache twice returns empty (no side-effects)
	✅ Non-empty cache returns data
	- Non-empty cache twice returns same data (no side-effects)
	- Error returns error (if applicable, e.g., invalid data)
	- Error twice returns same error (if applicable, e.g., invalid data)

- Insert
	✅ To empty cache stores data
	- To non-empty cache overrides previous data with new data
	- Error (if applicable, e.g., no write permission)

- Delete
	- Empty cache does nothing (cache stays empty and does not fail)
	- Non-empty cache leaves cache empty
	- Error (if applicable, e.g., no delete permission)

- Side-effects must run serially to avoid race conditions