### PR TITLE
CodableFeedStore final implementation (threading)

### DIFF
--- a/EssentialFeed/EssentialFeed/Feed API/HTTPClient.swift
+++ b/EssentialFeed/EssentialFeed/Feed API/HTTPClient.swift
@@ -10,5 +10,7 @@ public enum HTTPClientResult {
 }
 
 public protocol HTTPClient {
+	/// The completion handler can be invoked in any thread.
+	/// Clients are responsible to dispatch to appropriate threads, if needed.
 	func get(from url: URL, completion: @escaping (HTTPClientResult) -> Void)
 }

--- a/EssentialFeed/EssentialFeed/Feed Cache/CodableFeedStore.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/CodableFeedStore.swift
@@ -32,6 +32,7 @@ public class CodableFeedStore: FeedStore {
 		}
 	}
 	
+	private let queue = DispatchQueue(label: "\(CodableFeedStore.self)Queue", qos: .userInitiated)
 	private let storeURL: URL
 	
 	public init(storeURL: URL) {
@@ -39,41 +40,50 @@ public class CodableFeedStore: FeedStore {
 	}
 	
 	public func retrieve(completion: @escaping RetrievalCompletion) {
-		guard let data = try? Data(contentsOf: storeURL) else {
-			return completion(.empty)
-		}
-		
-		do {
-			let decoder = JSONDecoder()
-			let cache = try decoder.decode(Cache.self, from: data)
-			completion(.found(feed: cache.localFeed, timestamp: cache.timestamp))
-		} catch {
-			completion(.failure(error))
+		let storeURL = self.storeURL
+		queue.async {
+			guard let data = try? Data(contentsOf: storeURL) else {
+				return completion(.empty)
+			}
+			
+			do {
+				let decoder = JSONDecoder()
+				let cache = try decoder.decode(Cache.self, from: data)
+				completion(.found(feed: cache.localFeed, timestamp: cache.timestamp))
+			} catch {
+				completion(.failure(error))
+			}
 		}
 	}
 	
 	public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
-		do {
-			let encoder = JSONEncoder()
-			let cache = Cache(feed: feed.map(CodableFeedImage.init), timestamp: timestamp)
-			let encoded = try encoder.encode(cache)
-			try encoded.write(to: storeURL)
-			completion(nil)
-		} catch {
-			completion(error)
+		let storeURL = self.storeURL
+		queue.async {
+			do {
+				let encoder = JSONEncoder()
+				let cache = Cache(feed: feed.map(CodableFeedImage.init), timestamp: timestamp)
+				let encoded = try encoder.encode(cache)
+				try encoded.write(to: storeURL)
+				completion(nil)
+			} catch {
+				completion(error)
+			}
 		}
 	}
 	
 	public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
-		guard FileManager.default.fileExists(atPath: storeURL.path) else {
-			return completion(nil)
-		}
-		
-		do {
-			try FileManager.default.removeItem(at: storeURL)
-			completion(nil)
-		} catch {
-			completion(error)
+		let storeURL = self.storeURL
+		queue.async {
+			guard FileManager.default.fileExists(atPath: storeURL.path) else {
+				return completion(nil)
+			}
+			
+			do {
+				try FileManager.default.removeItem(at: storeURL)
+				completion(nil)
+			} catch {
+				completion(error)
+			}
 		}
 	}
 }

--- a/EssentialFeed/EssentialFeed/Feed Cache/CodableFeedStore.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/CodableFeedStore.swift
@@ -32,7 +32,7 @@ public class CodableFeedStore: FeedStore {
 		}
 	}
 	
-	private let queue = DispatchQueue(label: "\(CodableFeedStore.self)Queue", qos: .userInitiated)
+	private let queue = DispatchQueue(label: "\(CodableFeedStore.self)Queue", qos: .userInitiated, attributes: .concurrent)
 	private let storeURL: URL
 	
 	public init(storeURL: URL) {
@@ -58,7 +58,7 @@ public class CodableFeedStore: FeedStore {
 	
 	public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
 		let storeURL = self.storeURL
-		queue.async {
+		queue.async(flags: .barrier) {
 			do {
 				let encoder = JSONEncoder()
 				let cache = Cache(feed: feed.map(CodableFeedImage.init), timestamp: timestamp)
@@ -73,7 +73,7 @@ public class CodableFeedStore: FeedStore {
 	
 	public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
 		let storeURL = self.storeURL
-		queue.async {
+		queue.async(flags: .barrier) {
 			guard FileManager.default.fileExists(atPath: storeURL.path) else {
 				return completion(nil)
 			}

--- a/EssentialFeed/EssentialFeed/Feed Cache/FeedStore.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/FeedStore.swift
@@ -14,8 +14,16 @@ public protocol FeedStore {
 	typealias DeletionCompletion = (Error?) -> Void
 	typealias InsertionCompletion = (Error?) -> Void
 	typealias RetrievalCompletion = (RetrieveCachedFeedResult) -> Void
-	
+
+	/// The completion handler can be invoked in any thread.
+	/// Clients are responsible to dispatch to appropriate threads, if needed.
 	func deleteCachedFeed(completion: @escaping DeletionCompletion)
+	
+	/// The completion handler can be invoked in any thread.
+	/// Clients are responsible to dispatch to appropriate threads, if needed.
 	func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion)
+	
+	/// The completion handler can be invoked in any thread.
+	/// Clients are responsible to dispatch to appropriate threads, if needed.
 	func retrieve(completion: @escaping RetrievalCompletion)
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CodableFeedStoreTests.swift
@@ -123,6 +123,33 @@ class CodableFeedStoreTests: XCTestCase {
 		XCTAssertNotNil(deletionError, "Expected cache deletion to fail")
 		expect(sut, toRetrieve: .empty)
 	}
+	
+	func test_storeSideEffects_runSerially() {
+		let sut = makeSUT()
+		var completedOperationsInOrder = [XCTestExpectation]()
+		
+		let op1 = expectation(description: "Operation 1")
+		sut.insert(uniqueImageFeed().local, timestamp: Date()) { _ in
+			completedOperationsInOrder.append(op1)
+			op1.fulfill()
+		}
+		
+		let op2 = expectation(description: "Operation 2")
+		sut.deleteCachedFeed { _ in
+			completedOperationsInOrder.append(op2)
+			op2.fulfill()
+		}
+		
+		let op3 = expectation(description: "Operation 3")
+		sut.insert(uniqueImageFeed().local, timestamp: Date()) { _ in
+			completedOperationsInOrder.append(op3)
+			op3.fulfill()
+		}
+		
+		waitForExpectations(timeout: 5.0)
+		
+		XCTAssertEqual(completedOperationsInOrder, [op1, op2, op3], "Expected side-effects to run serially but operations finished in the wrong order")
+	}
 
 	// - MARK: Helpers
 	


### PR DESCRIPTION
- [x] Retrieve
    - [x] Empty cache returns empty
    - [x] Empty cache twice returns empty (no side-effects)
    - [x] Non-empty cache returns data
    - [x] Non-empty cache twice returns same data (no side-effects)
    - [x] Error returns error (if applicable, e.g., invalid data)
    - [x] Error twice returns same error (if applicable, e.g., invalid data)
- [x] Insert
    - [x] To empty cache stores data
    - [x] To non-empty cache overrides previous data with new data
    - [x] Error (if applicable, e.g., no write permission)
- [x] Delete
    - [x] Empty cache does nothing (cache stays empty and does not fail)
    - [x] Non-empty cache leaves cache empty
    - [x] Error (if applicable, e.g., no delete permission)
- [x] Side-effects must run serially to avoid race-conditions
