### PR TITLE
Swift 5 migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 os: osx
-osx_image: xcode10.1
+osx_image: xcode10.2
 language: swift
 script: xcodebuild clean build test -project EssentialFeed/EssentialFeed.xcodeproj -scheme "CI" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -438,6 +438,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 080EDEE721B6DA7E00813479;
 			productRefGroup = 080EDEF221B6DA7E00813479 /* Products */;

--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -416,17 +416,19 @@
 				TargetAttributes = {
 					080EDEF021B6DA7E00813479 = {
 						CreatedOnToolsVersion = 10.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 					};
 					080EDEF921B6DA7E00813479 = {
 						CreatedOnToolsVersion = 10.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 					};
 					0832C67C22A0223A00E1C5E9 = {
 						CreatedOnToolsVersion = 10.1;
+						LastSwiftMigration = 1020;
 					};
 					0899395B220359C50031B03D = {
 						CreatedOnToolsVersion = 10.1;
+						LastSwiftMigration = 1020;
 					};
 				};
 			};
@@ -713,7 +715,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -740,7 +742,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.essentialdeveloper.EssentialFeed;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -761,7 +763,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.essentialdeveloper.EssentialFeedTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -781,7 +783,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.essentialdeveloper.EssentialFeedTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -799,7 +801,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.essentialdeveloper.EssentialFeedCacheIntegrationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -817,7 +819,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.essentialdeveloper.EssentialFeedCacheIntegrationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -835,7 +837,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.essentialdeveloper.EssentialFeedAPIEndToEndTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -853,7 +855,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.essentialdeveloper.EssentialFeedAPIEndToEndTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/EssentialFeed/EssentialFeed/Feed API/FeedItemsMapper.swift
+++ b/EssentialFeed/EssentialFeed/Feed API/FeedItemsMapper.swift
@@ -4,14 +4,14 @@
 
 import Foundation
 
-internal final class FeedItemsMapper {
+final class FeedItemsMapper {
 	private struct Root: Decodable {
 		let items: [RemoteFeedItem]
 	}
 	
 	private static var OK_200: Int { return 200 }
 	
-	internal static func map(_ data: Data, from response: HTTPURLResponse) throws -> [RemoteFeedItem] {
+	static func map(_ data: Data, from response: HTTPURLResponse) throws -> [RemoteFeedItem] {
 		guard response.statusCode == OK_200,
 			let root = try? JSONDecoder().decode(Root.self, from: data) else {
 			throw RemoteFeedLoader.Error.invalidData

--- a/EssentialFeed/EssentialFeed/Feed API/HTTPClient.swift
+++ b/EssentialFeed/EssentialFeed/Feed API/HTTPClient.swift
@@ -4,13 +4,10 @@
 
 import Foundation
 
-public enum HTTPClientResult {
-	case success(Data, HTTPURLResponse)
-	case failure(Error)
-}
-
 public protocol HTTPClient {
+	typealias Result = Swift.Result<(Data, HTTPURLResponse), Error>
+	
 	/// The completion handler can be invoked in any thread.
 	/// Clients are responsible to dispatch to appropriate threads, if needed.
-	func get(from url: URL, completion: @escaping (HTTPClientResult) -> Void)
+	func get(from url: URL, completion: @escaping (Result) -> Void)
 }

--- a/EssentialFeed/EssentialFeed/Feed API/RemoteFeedItem.swift
+++ b/EssentialFeed/EssentialFeed/Feed API/RemoteFeedItem.swift
@@ -4,9 +4,9 @@
 
 import Foundation
 
-internal struct RemoteFeedItem: Decodable {
-	internal let id: UUID
-	internal let description: String?
-	internal let location: String?
-	internal let image: URL
+struct RemoteFeedItem: Decodable {
+	let id: UUID
+	let description: String?
+	let location: String?
+	let image: URL
 }

--- a/EssentialFeed/EssentialFeed/Feed API/RemoteFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed API/RemoteFeedLoader.swift
@@ -13,7 +13,7 @@ public final class RemoteFeedLoader: FeedLoader {
 		case invalidData
 	}
 	
-	public typealias Result = LoadFeedResult
+	public typealias Result = FeedLoader.Result
 	
 	public init(url: URL, client: HTTPClient) {
 		self.url = url

--- a/EssentialFeed/EssentialFeed/Feed API/URLSessionHTTPClient.swift
+++ b/EssentialFeed/EssentialFeed/Feed API/URLSessionHTTPClient.swift
@@ -13,12 +13,12 @@ public class URLSessionHTTPClient: HTTPClient {
 	
 	private struct UnexpectedValuesRepresentation: Error {}
 	
-	public func get(from url: URL, completion: @escaping (HTTPClientResult) -> Void) {
+	public func get(from url: URL, completion: @escaping (HTTPClient.Result) -> Void) {
 		session.dataTask(with: url) { data, response, error in
 			if let error = error {
 				completion(.failure(error))
 			} else if let data = data, let response = response as? HTTPURLResponse {
-				completion(.success(data, response))
+				completion(.success((data, response)))
 			} else {
 				completion(.failure(UnexpectedValuesRepresentation()))
 			}

--- a/EssentialFeed/EssentialFeed/Feed API/URLSessionHTTPClient.swift
+++ b/EssentialFeed/EssentialFeed/Feed API/URLSessionHTTPClient.swift
@@ -15,13 +15,15 @@ public class URLSessionHTTPClient: HTTPClient {
 	
 	public func get(from url: URL, completion: @escaping (HTTPClient.Result) -> Void) {
 		session.dataTask(with: url) { data, response, error in
-			if let error = error {
-				completion(.failure(error))
-			} else if let data = data, let response = response as? HTTPURLResponse {
-				completion(.success((data, response)))
-			} else {
-				completion(.failure(UnexpectedValuesRepresentation()))
-			}
+			completion(Result {
+				if let error = error {
+					throw error
+				} else if let data = data, let response = response as? HTTPURLResponse {
+					return (data, response)
+				} else {
+					throw UnexpectedValuesRepresentation()
+				}
+			})
 		}.resume()
 	}
 }

--- a/EssentialFeed/EssentialFeed/Feed Cache/FeedCachePolicy.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/FeedCachePolicy.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-internal final class FeedCachePolicy {
+final class FeedCachePolicy {
 	private init() {}
 	
 	private static let calendar = Calendar(identifier: .gregorian)
@@ -13,7 +13,7 @@ internal final class FeedCachePolicy {
 		return 7
 	}
 	
-	internal static func validate(_ timestamp: Date, against date: Date) -> Bool {
+	static func validate(_ timestamp: Date, against date: Date) -> Bool {
 		guard let maxCacheAge = calendar.date(byAdding: .day, value: maxCacheAgeInDays, to: timestamp) else {
 			return false
 		}

--- a/EssentialFeed/EssentialFeed/Feed Cache/FeedStore.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/FeedStore.swift
@@ -7,8 +7,11 @@ import Foundation
 public typealias CachedFeed = (feed: [LocalFeedImage], timestamp: Date)
 
 public protocol FeedStore {
-	typealias DeletionCompletion = (Error?) -> Void
-	typealias InsertionCompletion = (Error?) -> Void
+	typealias DeletionResult = Error?
+	typealias DeletionCompletion = (DeletionResult) -> Void
+	
+	typealias InsertionResult = Error?
+	typealias InsertionCompletion = (InsertionResult) -> Void
 	
 	typealias RetrievalResult = Result<CachedFeed?, Error>
 	typealias RetrievalCompletion = (RetrievalResult) -> Void

--- a/EssentialFeed/EssentialFeed/Feed Cache/FeedStore.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/FeedStore.swift
@@ -4,16 +4,17 @@
 
 import Foundation
 
-public enum RetrieveCachedFeedResult {
+public enum CachedFeed {
 	case empty
 	case found(feed: [LocalFeedImage], timestamp: Date)
-	case failure(Error)
 }
 
 public protocol FeedStore {
 	typealias DeletionCompletion = (Error?) -> Void
 	typealias InsertionCompletion = (Error?) -> Void
-	typealias RetrievalCompletion = (RetrieveCachedFeedResult) -> Void
+	
+	typealias RetrievalResult = Result<CachedFeed, Error>
+	typealias RetrievalCompletion = (RetrievalResult) -> Void
 
 	/// The completion handler can be invoked in any thread.
 	/// Clients are responsible to dispatch to appropriate threads, if needed.

--- a/EssentialFeed/EssentialFeed/Feed Cache/FeedStore.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/FeedStore.swift
@@ -4,16 +4,13 @@
 
 import Foundation
 
-public enum CachedFeed {
-	case empty
-	case found(feed: [LocalFeedImage], timestamp: Date)
-}
+public typealias CachedFeed = (feed: [LocalFeedImage], timestamp: Date)
 
 public protocol FeedStore {
 	typealias DeletionCompletion = (Error?) -> Void
 	typealias InsertionCompletion = (Error?) -> Void
 	
-	typealias RetrievalResult = Result<CachedFeed, Error>
+	typealias RetrievalResult = Result<CachedFeed?, Error>
 	typealias RetrievalCompletion = (RetrievalResult) -> Void
 
 	/// The completion handler can be invoked in any thread.

--- a/EssentialFeed/EssentialFeed/Feed Cache/FeedStore.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/FeedStore.swift
@@ -7,10 +7,10 @@ import Foundation
 public typealias CachedFeed = (feed: [LocalFeedImage], timestamp: Date)
 
 public protocol FeedStore {
-	typealias DeletionResult = Error?
+	typealias DeletionResult = Result<Void, Error>
 	typealias DeletionCompletion = (DeletionResult) -> Void
 	
-	typealias InsertionResult = Error?
+	typealias InsertionResult = Result<Void, Error>
 	typealias InsertionCompletion = (InsertionResult) -> Void
 	
 	typealias RetrievalResult = Result<CachedFeed?, Error>

--- a/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
@@ -35,9 +35,9 @@ public final class CoreDataFeedStore: FeedStore {
 				managedCache.feed = ManagedFeedImage.images(from: feed, in: context)
 				
 				try context.save()
-				completion(nil)
+				completion(.success(()))
 			} catch {
-				completion(error)
+				completion(.failure(error))
 			}
 		}
 	}
@@ -46,9 +46,9 @@ public final class CoreDataFeedStore: FeedStore {
 		perform { context in
 			do {
 				try ManagedCache.find(in: context).map(context.delete).map(context.save)
-				completion(nil)
+				completion(.success(()))
 			} catch {
-				completion(error)
+				completion(.failure(error))
 			}
 		}
 	}

--- a/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
@@ -17,9 +17,9 @@ public final class CoreDataFeedStore: FeedStore {
 		perform { context in
 			do {
 				if let cache = try ManagedCache.find(in: context) {
-					completion(.found(feed: cache.localFeed, timestamp: cache.timestamp))
+					completion(.success(.found(feed: cache.localFeed, timestamp: cache.timestamp)))
 				} else {
-					completion(.empty)
+					completion(.success(.empty))
 				}
 			} catch {
 				completion(.failure(error))

--- a/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
@@ -15,41 +15,30 @@ public final class CoreDataFeedStore: FeedStore {
 
 	public func retrieve(completion: @escaping RetrievalCompletion) {
 		perform { context in
-			do {
-				if let cache = try ManagedCache.find(in: context) {
-					completion(.success(CachedFeed(feed: cache.localFeed, timestamp: cache.timestamp)))
-				} else {
-					completion(.success(.none))
+			completion(Result {
+				try ManagedCache.find(in: context).map {
+					return CachedFeed(feed: $0.localFeed, timestamp: $0.timestamp)
 				}
-			} catch {
-				completion(.failure(error))
-			}
+			})
 		}
 	}
 	
 	public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
 		perform { context in
-			do {
+			completion(Result {
 				let managedCache = try ManagedCache.newUniqueInstance(in: context)
 				managedCache.timestamp = timestamp
 				managedCache.feed = ManagedFeedImage.images(from: feed, in: context)
-				
 				try context.save()
-				completion(.success(()))
-			} catch {
-				completion(.failure(error))
-			}
+			})
 		}
 	}
 
 	public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
 		perform { context in
-			do {
+			completion(Result {
 				try ManagedCache.find(in: context).map(context.delete).map(context.save)
-				completion(.success(()))
-			} catch {
-				completion(.failure(error))
-			}
+			})
 		}
 	}
 

--- a/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
@@ -17,9 +17,9 @@ public final class CoreDataFeedStore: FeedStore {
 		perform { context in
 			do {
 				if let cache = try ManagedCache.find(in: context) {
-					completion(.success(.found(feed: cache.localFeed, timestamp: cache.timestamp)))
+					completion(.success(CachedFeed(feed: cache.localFeed, timestamp: cache.timestamp)))
 				} else {
-					completion(.success(.empty))
+					completion(.success(.none))
 				}
 			} catch {
 				completion(.failure(error))

--- a/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataHelpers.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataHelpers.swift
@@ -4,13 +4,13 @@
 
 import CoreData
 
-internal extension NSPersistentContainer {
-	internal enum LoadingError: Swift.Error {
+extension NSPersistentContainer {
+	enum LoadingError: Swift.Error {
 		case modelNotFound
 		case failedToLoadPersistentStores(Swift.Error)
 	}
 	
-	internal static func load(modelName name: String, url: URL, in bundle: Bundle) throws -> NSPersistentContainer {
+	static func load(modelName name: String, url: URL, in bundle: Bundle) throws -> NSPersistentContainer {
 		guard let model = NSManagedObjectModel.with(name: name, in: bundle) else {
 			throw LoadingError.modelNotFound
 		}

--- a/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/ManagedCache.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/ManagedCache.swift
@@ -5,24 +5,24 @@
 import CoreData
 
 @objc(ManagedCache)
-internal class ManagedCache: NSManagedObject {
-	@NSManaged internal var timestamp: Date
-	@NSManaged internal var feed: NSOrderedSet
+class ManagedCache: NSManagedObject {
+	@NSManaged var timestamp: Date
+	@NSManaged var feed: NSOrderedSet
 }
 
 extension ManagedCache {
-	internal static func find(in context: NSManagedObjectContext) throws -> ManagedCache? {
+	static func find(in context: NSManagedObjectContext) throws -> ManagedCache? {
 		let request = NSFetchRequest<ManagedCache>(entityName: entity().name!)
 		request.returnsObjectsAsFaults = false
 		return try context.fetch(request).first
 	}
 	
-	internal static func newUniqueInstance(in context: NSManagedObjectContext) throws -> ManagedCache {
+	static func newUniqueInstance(in context: NSManagedObjectContext) throws -> ManagedCache {
 		try find(in: context).map(context.delete)
 		return ManagedCache(context: context)
 	}
 	
-	internal var localFeed: [LocalFeedImage] {
+	var localFeed: [LocalFeedImage] {
 		return feed.compactMap { ($0 as? ManagedFeedImage)?.local }
 	}
 }

--- a/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/ManagedFeedImage.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/ManagedFeedImage.swift
@@ -5,16 +5,16 @@
 import CoreData
 
 @objc(ManagedFeedImage)
-internal class ManagedFeedImage: NSManagedObject {
-	@NSManaged internal var id: UUID
-	@NSManaged internal var imageDescription: String?
-	@NSManaged internal var location: String?
-	@NSManaged internal var url: URL
-	@NSManaged internal var cache: ManagedCache
+class ManagedFeedImage: NSManagedObject {
+	@NSManaged var id: UUID
+	@NSManaged var imageDescription: String?
+	@NSManaged var location: String?
+	@NSManaged var url: URL
+	@NSManaged var cache: ManagedCache
 }
 
 extension ManagedFeedImage {
-	internal static func images(from localFeed: [LocalFeedImage], in context: NSManagedObjectContext) -> NSOrderedSet {
+	static func images(from localFeed: [LocalFeedImage], in context: NSManagedObjectContext) -> NSOrderedSet {
 		return NSOrderedSet(array: localFeed.map { local in
 			let managed = ManagedFeedImage(context: context)
 			managed.id = local.id
@@ -25,7 +25,7 @@ extension ManagedFeedImage {
 		})
 	}
 	
-	internal var local: LocalFeedImage {
+	var local: LocalFeedImage {
 		return LocalFeedImage(id: id, description: imageDescription, location: location, url: url)
 	}
 }

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -39,7 +39,7 @@ extension LocalFeedLoader {
 }
 
 extension LocalFeedLoader: FeedLoader {
-	public typealias LoadResult = LoadFeedResult
+	public typealias LoadResult = FeedLoader.Result
 
 	public func load(completion: @escaping (LoadResult) -> Void) {
 		store.retrieve { [weak self] result in

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -49,10 +49,10 @@ extension LocalFeedLoader: FeedLoader {
 			case let .failure(error):
 				completion(.failure(error))
 
-			case let .found(feed, timestamp) where FeedCachePolicy.validate(timestamp, against: self.currentDate()):
-				completion(.success(feed.toModels()))
+			case let .success(.found(cache)) where FeedCachePolicy.validate(cache.timestamp, against: self.currentDate()):
+				completion(.success(cache.feed.toModels()))
 				
-			case .found, .empty:
+			case .success:
 				completion(.success([]))
 			}
 		}
@@ -68,10 +68,10 @@ extension LocalFeedLoader {
 			case .failure:
 				self.store.deleteCachedFeed { _ in }
 				
-			case let .found(_, timestamp) where !FeedCachePolicy.validate(timestamp, against: self.currentDate()):
+			case let .success(.found(cache)) where !FeedCachePolicy.validate(cache.timestamp, against: self.currentDate()):
 				self.store.deleteCachedFeed { _ in }
 				
-			case .empty, .found: break
+			case .success: break
 			}
 		}
 	}

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -15,25 +15,27 @@ public final class LocalFeedLoader {
 }
 
 extension LocalFeedLoader {
-	public typealias SaveResult = Error?
+	public typealias SaveResult = Result<Void, Error>
 
 	public func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void) {
-		store.deleteCachedFeed { [weak self] error in
+		store.deleteCachedFeed { [weak self] deletionResult in
 			guard let self = self else { return }
 			
-			if let cacheDeletionError = error {
-				completion(cacheDeletionError)
-			} else {
+			switch deletionResult {
+			case .success:
 				self.cache(feed, with: completion)
+			
+			case let .failure(error):
+				completion(.failure(error))
 			}
 		}
 	}
 	
 	private func cache(_ feed: [FeedImage], with completion: @escaping (SaveResult) -> Void) {
-		store.insert(feed.toLocal(), timestamp: currentDate()) { [weak self] error in
+		store.insert(feed.toLocal(), timestamp: currentDate()) { [weak self] insertionResult in
 			guard self != nil else { return }
 			
-			completion(error)
+			completion(insertionResult)
 		}
 	}
 }

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -49,7 +49,7 @@ extension LocalFeedLoader: FeedLoader {
 			case let .failure(error):
 				completion(.failure(error))
 
-			case let .success(.found(cache)) where FeedCachePolicy.validate(cache.timestamp, against: self.currentDate()):
+			case let .success(.some(cache)) where FeedCachePolicy.validate(cache.timestamp, against: self.currentDate()):
 				completion(.success(cache.feed.toModels()))
 				
 			case .success:
@@ -68,7 +68,7 @@ extension LocalFeedLoader {
 			case .failure:
 				self.store.deleteCachedFeed { _ in }
 				
-			case let .success(.found(cache)) where !FeedCachePolicy.validate(cache.timestamp, against: self.currentDate()):
+			case let .success(.some(cache)) where !FeedCachePolicy.validate(cache.timestamp, against: self.currentDate()):
 				self.store.deleteCachedFeed { _ in }
 				
 			case .success: break

--- a/EssentialFeed/EssentialFeed/Feed Feature/FeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Feature/FeedLoader.swift
@@ -4,10 +4,7 @@
 
 import Foundation
 
-public enum LoadFeedResult {
-	case success([FeedImage])
-	case failure(Error)
-}
+public typealias LoadFeedResult = Result<[FeedImage], Error>
 
 public protocol FeedLoader {
 	func load(completion: @escaping (LoadFeedResult) -> Void)

--- a/EssentialFeed/EssentialFeed/Feed Feature/FeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Feature/FeedLoader.swift
@@ -4,8 +4,8 @@
 
 import Foundation
 
-public typealias LoadFeedResult = Result<[FeedImage], Error>
-
 public protocol FeedLoader {
-	func load(completion: @escaping (LoadFeedResult) -> Void)
+	typealias Result = Swift.Result<[FeedImage], Error>
+	
+	func load(completion: @escaping (Result) -> Void)
 }

--- a/EssentialFeed/EssentialFeedAPIEndToEndTests/EssentialFeedAPIEndToEndTests.swift
+++ b/EssentialFeed/EssentialFeedAPIEndToEndTests/EssentialFeedAPIEndToEndTests.swift
@@ -30,7 +30,7 @@ class EssentialFeedAPIEndToEndTests: XCTestCase {
 	
 	// MARK: - Helpers
 	
-	private func getFeedResult(file: StaticString = #file, line: UInt = #line) -> LoadFeedResult? {
+	private func getFeedResult(file: StaticString = #file, line: UInt = #line) -> FeedLoader.Result? {
 		let testServerURL = URL(string: "https://essentialdeveloper.com/feed-case-study/test-api/feed")!
 		let client = URLSessionHTTPClient(session: URLSession(configuration: .ephemeral))
 		let loader = RemoteFeedLoader(url: testServerURL, client: client)
@@ -39,7 +39,7 @@ class EssentialFeedAPIEndToEndTests: XCTestCase {
 		
 		let exp = expectation(description: "Wait for load completion")
 		
-		var receivedResult: LoadFeedResult?
+		var receivedResult: FeedLoader.Result?
 		loader.load { result in
 			receivedResult = result
 			exp.fulfill()

--- a/EssentialFeed/EssentialFeedCacheIntegrationTests/EssentialFeedCacheIntegrationTests.swift
+++ b/EssentialFeed/EssentialFeedCacheIntegrationTests/EssentialFeedCacheIntegrationTests.swift
@@ -62,8 +62,10 @@ class EssentialFeedCacheIntegrationTests: XCTestCase {
 	
 	private func save(_ feed: [FeedImage], with loader: LocalFeedLoader, file: StaticString = #file, line: UInt = #line) {
 		let saveExp = expectation(description: "Wait for save completion")
-		loader.save(feed) { saveError in
-			XCTAssertNil(saveError, "Expected to save feed successfully", file: file, line: line)
+		loader.save(feed) { result in
+			if case let Result.failure(error) = result {
+				XCTAssertNil(error, "Expected to save feed successfully", file: file, line: line)
+			}
 			saveExp.fulfill()
 		}
 		wait(for: [saveExp], timeout: 1.0)

--- a/EssentialFeed/EssentialFeedTests/Feed API/LoadFeedFromRemoteUseCaseTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed API/LoadFeedFromRemoteUseCaseTests.swift
@@ -58,7 +58,7 @@ class LoadFeedFromRemoteUseCaseTests: XCTestCase {
 		let (sut, client) = makeSUT()
 		
 		expect(sut, toCompleteWith: failure(.invalidData), when: {
-			let invalidJSON = Data(bytes: "invalid json".utf8)
+			let invalidJSON = Data("invalid json".utf8)
 			client.complete(withStatusCode: 200, data: invalidJSON)
 		})
 	}

--- a/EssentialFeed/EssentialFeedTests/Feed API/LoadFeedFromRemoteUseCaseTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed API/LoadFeedFromRemoteUseCaseTests.swift
@@ -163,13 +163,13 @@ class LoadFeedFromRemoteUseCaseTests: XCTestCase {
 	}
 
 	private class HTTPClientSpy: HTTPClient {
-		private var messages = [(url: URL, completion: (HTTPClientResult) -> Void)]()
+		private var messages = [(url: URL, completion: (HTTPClient.Result) -> Void)]()
 		
 		var requestedURLs: [URL] {
 			return messages.map { $0.url }
 		}
 		
-		func get(from url: URL, completion: @escaping (HTTPClientResult) -> Void) {
+		func get(from url: URL, completion: @escaping (HTTPClient.Result) -> Void) {
 			messages.append((url, completion))
 		}
 		
@@ -184,7 +184,7 @@ class LoadFeedFromRemoteUseCaseTests: XCTestCase {
 				httpVersion: nil,
 				headerFields: nil
 			)!
-			messages[index].completion(.success(data, response))
+			messages[index].completion(.success((data, response)))
 		}
 	}
 

--- a/EssentialFeed/EssentialFeedTests/Feed API/LoadFeedFromRemoteUseCaseTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed API/LoadFeedFromRemoteUseCaseTests.swift
@@ -129,9 +129,7 @@ class LoadFeedFromRemoteUseCaseTests: XCTestCase {
 			"description": description,
 			"location": location,
 			"image": imageURL.absoluteString
-		].reduce(into: [String: Any]()) { (acc, e) in
-			if let value = e.value { acc[e.key] = value }
-		}
+		].compactMapValues { $0 }
 		
 		return (item, json)
 	}

--- a/EssentialFeed/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
@@ -108,12 +108,12 @@ class URLSessionHTTPClientTests: XCTestCase {
 		}
 	}
 	
-	private func resultFor(data: Data?, response: URLResponse?, error: Error?, file: StaticString = #file, line: UInt = #line) -> HTTPClientResult {
+	private func resultFor(data: Data?, response: URLResponse?, error: Error?, file: StaticString = #file, line: UInt = #line) -> HTTPClient.Result {
 		URLProtocolStub.stub(data: data, response: response, error: error)
 		let sut = makeSUT(file: file, line: line)
 		let exp = expectation(description: "Wait for completion")
 		
-		var receivedResult: HTTPClientResult!
+		var receivedResult: HTTPClient.Result!
 		sut.get(from: anyURL()) { result in
 			receivedResult = result
 			exp.fulfill()

--- a/EssentialFeed/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
@@ -124,7 +124,7 @@ class URLSessionHTTPClientTests: XCTestCase {
 	}
 		
 	private func anyData() -> Data {
-		return Data(bytes: "any data".utf8)
+		return Data("any data".utf8)
 	}
 		
 	private func anyHTTPURLResponse() -> HTTPURLResponse {

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/CacheFeedUseCaseTests.swift
@@ -111,8 +111,8 @@ class CacheFeedUseCaseTests: XCTestCase {
 		let exp = expectation(description: "Wait for save completion")
 		
 		var receivedError: Error?
-		sut.save(uniqueImageFeed().models) { error in
-			receivedError = error
+		sut.save(uniqueImageFeed().models) { result in
+			if case let Result.failure(error) = result { receivedError = error }
 			exp.fulfill()
 		}
 		

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FailableDeleteFeedStoreSpecs.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FailableDeleteFeedStoreSpecs.swift
@@ -15,6 +15,6 @@ extension FailableDeleteFeedStoreSpecs where Self: XCTestCase {
 	func assertThatDeleteHasNoSideEffectsOnDeletionError(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
 		deleteCache(from: sut)
 		
-		expect(sut, toRetrieve: .success(.empty), file: file, line: line)
+		expect(sut, toRetrieve: .success(.none), file: file, line: line)
 	}
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FailableDeleteFeedStoreSpecs.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FailableDeleteFeedStoreSpecs.swift
@@ -15,6 +15,6 @@ extension FailableDeleteFeedStoreSpecs where Self: XCTestCase {
 	func assertThatDeleteHasNoSideEffectsOnDeletionError(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
 		deleteCache(from: sut)
 		
-		expect(sut, toRetrieve: .empty, file: file, line: line)
+		expect(sut, toRetrieve: .success(.empty), file: file, line: line)
 	}
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FailableInsertFeedStoreSpecs.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FailableInsertFeedStoreSpecs.swift
@@ -15,6 +15,6 @@ extension FailableInsertFeedStoreSpecs where Self: XCTestCase {
 	func assertThatInsertHasNoSideEffectsOnInsertionError(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
 		insert((uniqueImageFeed().local, Date()), to: sut)
 		
-		expect(sut, toRetrieve: .empty, file: file, line: line)
+		expect(sut, toRetrieve: .success(.empty), file: file, line: line)
 	}
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FailableInsertFeedStoreSpecs.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FailableInsertFeedStoreSpecs.swift
@@ -15,6 +15,6 @@ extension FailableInsertFeedStoreSpecs where Self: XCTestCase {
 	func assertThatInsertHasNoSideEffectsOnInsertionError(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
 		insert((uniqueImageFeed().local, Date()), to: sut)
 		
-		expect(sut, toRetrieve: .success(.empty), file: file, line: line)
+		expect(sut, toRetrieve: .success(.none), file: file, line: line)
 	}
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
@@ -118,8 +118,8 @@ extension FeedStoreSpecs where Self: XCTestCase {
 	func insert(_ cache: (feed: [LocalFeedImage], timestamp: Date), to sut: FeedStore) -> Error? {
 		let exp = expectation(description: "Wait for cache insertion")
 		var insertionError: Error?
-		sut.insert(cache.feed, timestamp: cache.timestamp) { receivedInsertionError in
-			insertionError = receivedInsertionError
+		sut.insert(cache.feed, timestamp: cache.timestamp) { result in
+			if case let Result.failure(error) = result { insertionError = error }
 			exp.fulfill()
 		}
 		wait(for: [exp], timeout: 1.0)
@@ -130,8 +130,8 @@ extension FeedStoreSpecs where Self: XCTestCase {
 	func deleteCache(from sut: FeedStore) -> Error? {
 		let exp = expectation(description: "Wait for cache deletion")
 		var deletionError: Error?
-		sut.deleteCachedFeed { receivedDeletionError in
-			deletionError = receivedDeletionError
+		sut.deleteCachedFeed { result in
+			if case let Result.failure(error) = result { deletionError = error }
 			exp.fulfill()
 		}
 		wait(for: [exp], timeout: 1.0)

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
@@ -8,11 +8,11 @@ import EssentialFeed
 extension FeedStoreSpecs where Self: XCTestCase {
 	
 	func assertThatRetrieveDeliversEmptyOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
-		expect(sut, toRetrieve: .success(.empty), file: file, line: line)
+		expect(sut, toRetrieve: .success(.none), file: file, line: line)
 	}
 	
 	func assertThatRetrieveHasNoSideEffectsOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
-		expect(sut, toRetrieveTwice: .success(.empty), file: file, line: line)
+		expect(sut, toRetrieveTwice: .success(.none), file: file, line: line)
 	}
 	
 	func assertThatRetrieveDeliversFoundValuesOnNonEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -21,7 +21,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
 		
 		insert((feed, timestamp), to: sut)
 		
-		expect(sut, toRetrieve: .success(.found(feed: feed, timestamp: timestamp)), file: file, line: line)
+		expect(sut, toRetrieve: .success(CachedFeed(feed: feed, timestamp: timestamp)), file: file, line: line)
 	}
 	
 	func assertThatRetrieveHasNoSideEffectsOnNonEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -30,7 +30,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
 		
 		insert((feed, timestamp), to: sut)
 		
-		expect(sut, toRetrieveTwice: .success(.found(feed: feed, timestamp: timestamp)), file: file, line: line)
+		expect(sut, toRetrieveTwice: .success(CachedFeed(feed: feed, timestamp: timestamp)), file: file, line: line)
 	}
 	
 	func assertThatInsertDeliversNoErrorOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -54,7 +54,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
 		let latestTimestamp = Date()
 		insert((latestFeed, latestTimestamp), to: sut)
 		
-		expect(sut, toRetrieve: .success(.found(feed: latestFeed, timestamp: latestTimestamp)), file: file, line: line)
+		expect(sut, toRetrieve: .success(CachedFeed(feed: latestFeed, timestamp: latestTimestamp)), file: file, line: line)
 	}
 
 	func assertThatDeleteDeliversNoErrorOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -66,7 +66,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
 	func assertThatDeleteHasNoSideEffectsOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
 		deleteCache(from: sut)
 		
-		expect(sut, toRetrieve: .success(.empty), file: file, line: line)
+		expect(sut, toRetrieve: .success(.none), file: file, line: line)
 	}
 
 	func assertThatDeleteDeliversNoErrorOnNonEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -82,7 +82,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
 		
 		deleteCache(from: sut)
 		
-		expect(sut, toRetrieve: .success(.empty), file: file, line: line)
+		expect(sut, toRetrieve: .success(.none), file: file, line: line)
 	}
 	
 	func assertThatSideEffectsRunSerially(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -148,11 +148,11 @@ extension FeedStoreSpecs where Self: XCTestCase {
 		
 		sut.retrieve { retrievedResult in
 			switch (expectedResult, retrievedResult) {
-			case (.success(.empty), .success(.empty)),
+			case (.success(.none), .success(.none)),
 				 (.failure, .failure):
 				break
 				
-			case let (.success(.found(expected)), .success(.found(retrieved))):
+			case let (.success(.some(expected)), .success(.some(retrieved))):
 				XCTAssertEqual(retrieved.feed, expected.feed, file: file, line: line)
 				XCTAssertEqual(retrieved.timestamp, expected.timestamp, file: file, line: line)
 				

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
@@ -8,11 +8,11 @@ import EssentialFeed
 extension FeedStoreSpecs where Self: XCTestCase {
 	
 	func assertThatRetrieveDeliversEmptyOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
-		expect(sut, toRetrieve: .empty, file: file, line: line)
+		expect(sut, toRetrieve: .success(.empty), file: file, line: line)
 	}
 	
 	func assertThatRetrieveHasNoSideEffectsOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
-		expect(sut, toRetrieveTwice: .empty, file: file, line: line)
+		expect(sut, toRetrieveTwice: .success(.empty), file: file, line: line)
 	}
 	
 	func assertThatRetrieveDeliversFoundValuesOnNonEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -21,7 +21,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
 		
 		insert((feed, timestamp), to: sut)
 		
-		expect(sut, toRetrieve: .found(feed: feed, timestamp: timestamp), file: file, line: line)
+		expect(sut, toRetrieve: .success(.found(feed: feed, timestamp: timestamp)), file: file, line: line)
 	}
 	
 	func assertThatRetrieveHasNoSideEffectsOnNonEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -30,7 +30,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
 		
 		insert((feed, timestamp), to: sut)
 		
-		expect(sut, toRetrieveTwice: .found(feed: feed, timestamp: timestamp), file: file, line: line)
+		expect(sut, toRetrieveTwice: .success(.found(feed: feed, timestamp: timestamp)), file: file, line: line)
 	}
 	
 	func assertThatInsertDeliversNoErrorOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -54,7 +54,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
 		let latestTimestamp = Date()
 		insert((latestFeed, latestTimestamp), to: sut)
 		
-		expect(sut, toRetrieve: .found(feed: latestFeed, timestamp: latestTimestamp), file: file, line: line)
+		expect(sut, toRetrieve: .success(.found(feed: latestFeed, timestamp: latestTimestamp)), file: file, line: line)
 	}
 
 	func assertThatDeleteDeliversNoErrorOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -66,7 +66,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
 	func assertThatDeleteHasNoSideEffectsOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
 		deleteCache(from: sut)
 		
-		expect(sut, toRetrieve: .empty, file: file, line: line)
+		expect(sut, toRetrieve: .success(.empty), file: file, line: line)
 	}
 
 	func assertThatDeleteDeliversNoErrorOnNonEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -82,7 +82,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
 		
 		deleteCache(from: sut)
 		
-		expect(sut, toRetrieve: .empty, file: file, line: line)
+		expect(sut, toRetrieve: .success(.empty), file: file, line: line)
 	}
 	
 	func assertThatSideEffectsRunSerially(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
@@ -138,21 +138,21 @@ extension FeedStoreSpecs where Self: XCTestCase {
 		return deletionError
 	}
 	
-	func expect(_ sut: FeedStore, toRetrieveTwice expectedResult: RetrieveCachedFeedResult, file: StaticString = #file, line: UInt = #line) {
+	func expect(_ sut: FeedStore, toRetrieveTwice expectedResult: FeedStore.RetrievalResult, file: StaticString = #file, line: UInt = #line) {
 		expect(sut, toRetrieve: expectedResult, file: file, line: line)
 		expect(sut, toRetrieve: expectedResult, file: file, line: line)
 	}
 	
-	func expect(_ sut: FeedStore, toRetrieve expectedResult: RetrieveCachedFeedResult, file: StaticString = #file, line: UInt = #line) {
+	func expect(_ sut: FeedStore, toRetrieve expectedResult: FeedStore.RetrievalResult, file: StaticString = #file, line: UInt = #line) {
 		let exp = expectation(description: "Wait for cache retrieval")
 		
 		sut.retrieve { retrievedResult in
 			switch (expectedResult, retrievedResult) {
-			case (.empty, .empty),
+			case (.success(.empty), .success(.empty)),
 				 (.failure, .failure):
 				break
 				
-			case let (.found(expected), .found(retrieved)):
+			case let (.success(.found(expected)), .success(.found(retrieved))):
 				XCTAssertEqual(retrieved.feed, expected.feed, file: file, line: line)
 				XCTAssertEqual(retrieved.timestamp, expected.timestamp, file: file, line: line)
 				

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
@@ -54,10 +54,10 @@ class FeedStoreSpy: FeedStore {
 	}
 	
 	func completeRetrievalWithEmptyCache(at index: Int = 0) {
-		retrievalCompletions[index](.empty)
+		retrievalCompletions[index](.success(.empty))
 	}
 	
 	func completeRetrieval(with feed: [LocalFeedImage], timestamp: Date, at index: Int = 0) {
-		retrievalCompletions[index](.found(feed: feed, timestamp: timestamp))
+		retrievalCompletions[index](.success(.found(feed: feed, timestamp: timestamp)))
 	}
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
@@ -54,10 +54,10 @@ class FeedStoreSpy: FeedStore {
 	}
 	
 	func completeRetrievalWithEmptyCache(at index: Int = 0) {
-		retrievalCompletions[index](.success(.empty))
+		retrievalCompletions[index](.success(.none))
 	}
 	
 	func completeRetrieval(with feed: [LocalFeedImage], timestamp: Date, at index: Int = 0) {
-		retrievalCompletions[index](.success(.found(feed: feed, timestamp: timestamp)))
+		retrievalCompletions[index](.success(CachedFeed(feed: feed, timestamp: timestamp)))
 	}
 }

--- a/EssentialFeed/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed Cache/Helpers/FeedStoreSpy.swift
@@ -24,11 +24,11 @@ class FeedStoreSpy: FeedStore {
 	}
 	
 	func completeDeletion(with error: Error, at index: Int = 0) {
-		deletionCompletions[index](error)
+		deletionCompletions[index](.failure(error))
 	}
 	
 	func completeDeletionSuccessfully(at index: Int = 0) {
-		deletionCompletions[index](nil)
+		deletionCompletions[index](.success(()))
 	}
 	
 	func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
@@ -37,11 +37,11 @@ class FeedStoreSpy: FeedStore {
 	}
 	
 	func completeInsertion(with error: Error, at index: Int = 0) {
-		insertionCompletions[index](error)
+		insertionCompletions[index](.failure(error))
 	}
 	
 	func completeInsertionSuccessfully(at index: Int = 0) {
-		insertionCompletions[index](nil)
+		insertionCompletions[index](.success(()))
 	}
 	
 	func retrieve(completion: @escaping RetrievalCompletion) {


### PR DESCRIPTION
Migrate to Swift 5 and refactor the code to use the standard `Swift.Result` type.