### PR TITLE
Fix URLSessionHTTPClient test data race

### DIFF
--- a/EssentialFeed/EssentialFeed.xcodeproj/xcshareddata/xcschemes/CI_iOS.xcscheme
+++ b/EssentialFeed/EssentialFeed.xcodeproj/xcshareddata/xcschemes/CI_iOS.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">

--- a/EssentialFeed/EssentialFeed.xcodeproj/xcshareddata/xcschemes/CI_macOS.xcscheme
+++ b/EssentialFeed/EssentialFeed.xcodeproj/xcshareddata/xcschemes/CI_macOS.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">

--- a/EssentialFeed/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
@@ -164,7 +164,6 @@ class URLSessionHTTPClientTests: XCTestCase {
 		}
 		
 		override class func canInit(with request: URLRequest) -> Bool {
-			requestObserver?(request)
 			return true
 		}
 		
@@ -173,6 +172,11 @@ class URLSessionHTTPClientTests: XCTestCase {
 		}
 		
 		override func startLoading() {
+			if let requestObserver = URLProtocolStub.requestObserver {
+				client?.urlProtocolDidFinishLoading(self)
+				return requestObserver(request)
+			}
+
 			if let data = URLProtocolStub.stub?.data {
 				client?.urlProtocol(self, didLoad: data)
 			}


### PR DESCRIPTION
Changed the `URLProtocolStub` implementation to make sure all background operations finish before the test methods return.