### PR TITLE
Loader Cache Decorators

### DIFF
--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0804862823633E780087ED48 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0804862723633E780087ED48 /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		0804862A2363416F0087ED48 /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080486292363416F0087ED48 /* FeedImageDataLoaderSpy.swift */; };
 		0804862C236341CD0087ED48 /* XCTestCase+FeedImageDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0804862B236341CD0087ED48 /* XCTestCase+FeedImageDataLoader.swift */; };
+		08048630236346090087ED48 /* FeedImageDataLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0804862F236346090087ED48 /* FeedImageDataLoaderCacheDecorator.swift */; };
 		08075B372354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08075B362354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift */; };
 		082C00012359E3B2008927D3 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082C00002359E3B2008927D3 /* FeedImageDataLoaderWithFallbackComposite.swift */; };
 		082C00042359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082C00032359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift */; };
@@ -60,6 +61,7 @@
 		0804862723633E780087ED48 /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		080486292363416F0087ED48 /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
 		0804862B236341CD0087ED48 /* XCTestCase+FeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedImageDataLoader.swift"; sourceTree = "<group>"; };
+		0804862F236346090087ED48 /* FeedImageDataLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		08075B362354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		082C00002359E3B2008927D3 /* FeedImageDataLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		082C00032359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
@@ -143,6 +145,7 @@
 				085BB637235A279C0013B282 /* FeedLoaderWithFallbackComposite.swift */,
 				08F8822E23649A6D00CAEE16 /* FeedLoaderCacheDecorator.swift */,
 				082C00002359E3B2008927D3 /* FeedImageDataLoaderWithFallbackComposite.swift */,
+				0804862F236346090087ED48 /* FeedImageDataLoaderCacheDecorator.swift */,
 				0895DA8C234B3B950031BB2D /* Main.storyboard */,
 				0895DA8F234B3B970031BB2D /* Assets.xcassets */,
 				0895DA91234B3B970031BB2D /* LaunchScreen.storyboard */,
@@ -280,6 +283,7 @@
 				0895DA87234B3B950031BB2D /* AppDelegate.swift in Sources */,
 				085BB638235A279D0013B282 /* FeedLoaderWithFallbackComposite.swift in Sources */,
 				08F8822F23649A6D00CAEE16 /* FeedLoaderCacheDecorator.swift in Sources */,
+				08048630236346090087ED48 /* FeedImageDataLoaderCacheDecorator.swift in Sources */,
 				0895DA89234B3B950031BB2D /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		0895DAAE234B3F7E0031BB2D /* EssentialFeediOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0895DAAA234B3F7E0031BB2D /* EssentialFeediOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		08F8822723648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F8822623648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift */; };
 		08F882292364918600CAEE16 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F882282364918600CAEE16 /* FeedLoaderStub.swift */; };
+		08F8822B2364928100CAEE16 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F8822A2364928100CAEE16 /* XCTestCase+FeedLoader.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -71,6 +72,7 @@
 		0895DAAA234B3F7E0031BB2D /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		08F8822623648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		08F882282364918600CAEE16 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
+		08F8822A2364928100CAEE16 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +99,7 @@
 			isa = PBXGroup;
 			children = (
 				082C00032359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift */,
+				08F8822A2364928100CAEE16 /* XCTestCase+FeedLoader.swift */,
 				082C00052359E4C6008927D3 /* SharedTestHelpers.swift */,
 				08F882282364918600CAEE16 /* FeedLoaderStub.swift */,
 			);
@@ -273,6 +276,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				082C00062359E4C6008927D3 /* SharedTestHelpers.swift in Sources */,
+				08F8822B2364928100CAEE16 /* XCTestCase+FeedLoader.swift in Sources */,
 				08F8822723648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				082CFFFF2359D36A008927D3 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				08075B372354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0804862823633E780087ED48 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0804862723633E780087ED48 /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		08075B372354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08075B362354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift */; };
 		082C00012359E3B2008927D3 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082C00002359E3B2008927D3 /* FeedImageDataLoaderWithFallbackComposite.swift */; };
 		082C00042359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082C00032359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift */; };
@@ -54,6 +55,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0804862723633E780087ED48 /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		08075B362354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		082C00002359E3B2008927D3 /* FeedImageDataLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		082C00032359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
@@ -149,8 +151,9 @@
 				0895DA9F234B3B980031BB2D /* Info.plist */,
 				082C00022359E43F008927D3 /* Helpers */,
 				08075B362354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift */,
-				082CFFFE2359D36A008927D3 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */,
 				08F8822623648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift */,
+				082CFFFE2359D36A008927D3 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */,
+				0804862723633E780087ED48 /* FeedImageDataLoaderCacheDecoratorTests.swift */,
 			);
 			path = EssentialAppTests;
 			sourceTree = "<group>";
@@ -282,6 +285,7 @@
 				082C00062359E4C6008927D3 /* SharedTestHelpers.swift in Sources */,
 				08F8822B2364928100CAEE16 /* XCTestCase+FeedLoader.swift in Sources */,
 				08F8822723648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
+				0804862823633E780087ED48 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				082CFFFF2359D36A008927D3 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				08075B372354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				08F882292364918600CAEE16 /* FeedLoaderStub.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0804862823633E780087ED48 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0804862723633E780087ED48 /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		0804862A2363416F0087ED48 /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080486292363416F0087ED48 /* FeedImageDataLoaderSpy.swift */; };
+		0804862C236341CD0087ED48 /* XCTestCase+FeedImageDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0804862B236341CD0087ED48 /* XCTestCase+FeedImageDataLoader.swift */; };
 		08075B372354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08075B362354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift */; };
 		082C00012359E3B2008927D3 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082C00002359E3B2008927D3 /* FeedImageDataLoaderWithFallbackComposite.swift */; };
 		082C00042359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082C00032359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift */; };
@@ -58,6 +59,7 @@
 /* Begin PBXFileReference section */
 		0804862723633E780087ED48 /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		080486292363416F0087ED48 /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
+		0804862B236341CD0087ED48 /* XCTestCase+FeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedImageDataLoader.swift"; sourceTree = "<group>"; };
 		08075B362354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		082C00002359E3B2008927D3 /* FeedImageDataLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		082C00032359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
@@ -106,6 +108,7 @@
 			children = (
 				082C00032359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift */,
 				08F8822A2364928100CAEE16 /* XCTestCase+FeedLoader.swift */,
+				0804862B236341CD0087ED48 /* XCTestCase+FeedImageDataLoader.swift */,
 				082C00052359E4C6008927D3 /* SharedTestHelpers.swift */,
 				08F882282364918600CAEE16 /* FeedLoaderStub.swift */,
 				080486292363416F0087ED48 /* FeedImageDataLoaderSpy.swift */,
@@ -289,6 +292,7 @@
 				08F8822B2364928100CAEE16 /* XCTestCase+FeedLoader.swift in Sources */,
 				08F8822723648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				0804862823633E780087ED48 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
+				0804862C236341CD0087ED48 /* XCTestCase+FeedImageDataLoader.swift in Sources */,
 				082CFFFF2359D36A008927D3 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				0804862A2363416F0087ED48 /* FeedImageDataLoaderSpy.swift in Sources */,
 				08075B372354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		08F8822723648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F8822623648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift */; };
 		08F882292364918600CAEE16 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F882282364918600CAEE16 /* FeedLoaderStub.swift */; };
 		08F8822B2364928100CAEE16 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F8822A2364928100CAEE16 /* XCTestCase+FeedLoader.swift */; };
+		08F8822F23649A6D00CAEE16 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F8822E23649A6D00CAEE16 /* FeedLoaderCacheDecorator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -73,6 +74,7 @@
 		08F8822623648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		08F882282364918600CAEE16 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		08F8822A2364928100CAEE16 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
+		08F8822E23649A6D00CAEE16 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -131,6 +133,7 @@
 				0895DA86234B3B950031BB2D /* AppDelegate.swift */,
 				0895DA88234B3B950031BB2D /* SceneDelegate.swift */,
 				085BB637235A279C0013B282 /* FeedLoaderWithFallbackComposite.swift */,
+				08F8822E23649A6D00CAEE16 /* FeedLoaderCacheDecorator.swift */,
 				082C00002359E3B2008927D3 /* FeedImageDataLoaderWithFallbackComposite.swift */,
 				0895DA8C234B3B950031BB2D /* Main.storyboard */,
 				0895DA8F234B3B970031BB2D /* Assets.xcassets */,
@@ -267,6 +270,7 @@
 				082C00012359E3B2008927D3 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */,
 				0895DA87234B3B950031BB2D /* AppDelegate.swift in Sources */,
 				085BB638235A279D0013B282 /* FeedLoaderWithFallbackComposite.swift in Sources */,
+				08F8822F23649A6D00CAEE16 /* FeedLoaderCacheDecorator.swift in Sources */,
 				0895DA89234B3B950031BB2D /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0804862823633E780087ED48 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0804862723633E780087ED48 /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
+		0804862A2363416F0087ED48 /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080486292363416F0087ED48 /* FeedImageDataLoaderSpy.swift */; };
 		08075B372354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08075B362354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift */; };
 		082C00012359E3B2008927D3 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082C00002359E3B2008927D3 /* FeedImageDataLoaderWithFallbackComposite.swift */; };
 		082C00042359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082C00032359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift */; };
@@ -56,6 +57,7 @@
 
 /* Begin PBXFileReference section */
 		0804862723633E780087ED48 /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
+		080486292363416F0087ED48 /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
 		08075B362354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		082C00002359E3B2008927D3 /* FeedImageDataLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		082C00032359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
@@ -106,6 +108,7 @@
 				08F8822A2364928100CAEE16 /* XCTestCase+FeedLoader.swift */,
 				082C00052359E4C6008927D3 /* SharedTestHelpers.swift */,
 				08F882282364918600CAEE16 /* FeedLoaderStub.swift */,
+				080486292363416F0087ED48 /* FeedImageDataLoaderSpy.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -287,6 +290,7 @@
 				08F8822723648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				0804862823633E780087ED48 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				082CFFFF2359D36A008927D3 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
+				0804862A2363416F0087ED48 /* FeedImageDataLoaderSpy.swift in Sources */,
 				08075B372354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				08F882292364918600CAEE16 /* FeedLoaderStub.swift in Sources */,
 				082C00042359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		0895DAAD234B3F7E0031BB2D /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0895DAAA234B3F7E0031BB2D /* EssentialFeediOS.framework */; };
 		0895DAAE234B3F7E0031BB2D /* EssentialFeediOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0895DAAA234B3F7E0031BB2D /* EssentialFeediOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		08F8822723648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F8822623648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift */; };
+		08F882292364918600CAEE16 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F882282364918600CAEE16 /* FeedLoaderStub.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +70,7 @@
 		0895DAA9234B3F7E0031BB2D /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0895DAAA234B3F7E0031BB2D /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		08F8822623648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
+		08F882282364918600CAEE16 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,6 +98,7 @@
 			children = (
 				082C00032359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift */,
 				082C00052359E4C6008927D3 /* SharedTestHelpers.swift */,
+				08F882282364918600CAEE16 /* FeedLoaderStub.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -273,6 +276,7 @@
 				08F8822723648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				082CFFFF2359D36A008927D3 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				08075B372354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
+				08F882292364918600CAEE16 /* FeedLoaderStub.swift in Sources */,
 				082C00042359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		0895DAAC234B3F7E0031BB2D /* EssentialFeed.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0895DAA9234B3F7E0031BB2D /* EssentialFeed.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0895DAAD234B3F7E0031BB2D /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0895DAAA234B3F7E0031BB2D /* EssentialFeediOS.framework */; };
 		0895DAAE234B3F7E0031BB2D /* EssentialFeediOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0895DAAA234B3F7E0031BB2D /* EssentialFeediOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		08F8822723648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F8822623648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,6 +68,7 @@
 		0895DA9F234B3B980031BB2D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0895DAA9234B3F7E0031BB2D /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0895DAAA234B3F7E0031BB2D /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		08F8822623648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -139,6 +141,7 @@
 				082C00022359E43F008927D3 /* Helpers */,
 				08075B362354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift */,
 				082CFFFE2359D36A008927D3 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */,
+				08F8822623648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift */,
 			);
 			path = EssentialAppTests;
 			sourceTree = "<group>";
@@ -267,6 +270,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				082C00062359E4C6008927D3 /* SharedTestHelpers.swift in Sources */,
+				08F8822723648F2000CAEE16 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				082CFFFF2359D36A008927D3 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				08075B372354C11A00127D3C /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				082C00042359E46C008927D3 /* XCTestCase+MemoryLeakTracking.swift in Sources */,

--- a/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
@@ -1,0 +1,25 @@
+//
+//  Copyright © 2019 Essential Developer. All rights reserved.
+//
+
+import Foundation
+import EssentialFeed
+
+public final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
+	private let decoratee: FeedImageDataLoader
+	private let cache: FeedImageDataCache
+
+	public init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
+		self.decoratee = decoratee
+		self.cache = cache
+	}
+	
+	public func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+		return decoratee.loadImageData(from: url) { [weak self] result in
+			completion(result.map { data in
+				self?.cache.save(data, for: url) { _ in }
+				return data
+			})
+		}
+	}
+}

--- a/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
@@ -17,9 +17,15 @@ public final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
 	public func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
 		return decoratee.loadImageData(from: url) { [weak self] result in
 			completion(result.map { data in
-				self?.cache.save(data, for: url) { _ in }
+				self?.cache.saveIgnoringResult(data, for: url)
 				return data
 			})
 		}
+	}
+}
+
+private extension FeedImageDataCache {
+	func saveIgnoringResult(_ data: Data, for url: URL) {
+		save(data, for: url) { _ in }
 	}
 }

--- a/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
@@ -16,9 +16,15 @@ public final class FeedLoaderCacheDecorator: FeedLoader {
 	public func load(completion: @escaping (FeedLoader.Result) -> Void) {
 		decoratee.load { [weak self] result in
 			completion(result.map { feed in
-				self?.cache.save(feed) { _ in }
+				self?.cache.saveIgnoringResult(feed)
 				return feed
 			})
 		}
+	}
+}
+
+private extension FeedCache {
+	func saveIgnoringResult(_ feed: [FeedImage]) {
+		save(feed) { _ in }
 	}
 }

--- a/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
@@ -1,0 +1,24 @@
+//
+//  Copyright © 2019 Essential Developer. All rights reserved.
+//
+
+import EssentialFeed
+
+public final class FeedLoaderCacheDecorator: FeedLoader {
+	private let decoratee: FeedLoader
+	private let cache: FeedCache
+	
+	public init(decoratee: FeedLoader, cache: FeedCache) {
+		self.decoratee = decoratee
+		self.cache = cache
+	}
+	
+	public func load(completion: @escaping (FeedLoader.Result) -> Void) {
+		decoratee.load { [weak self] result in
+			completion(result.map { feed in
+				self?.cache.save(feed) { _ in }
+				return feed
+			})
+		}
+	}
+}

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -64,8 +64,8 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
 
 	// MARK: - Helpers
 		
-	private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: LoaderSpy) {
-		let loader = LoaderSpy()
+	private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: FeedImageDataLoaderSpy) {
+		let loader = FeedImageDataLoaderSpy()
 		let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
 		trackForMemoryLeaks(loader, file: file, line: line)
 		trackForMemoryLeaks(sut, file: file, line: line)
@@ -95,33 +95,4 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
 		wait(for: [exp], timeout: 1.0)
 	}
 	
-	private class LoaderSpy: FeedImageDataLoader {
-		private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
-
-		private(set) var cancelledURLs = [URL]()
-
-		var loadedURLs: [URL] {
-			return messages.map { $0.url }
-		}
-
-		private struct Task: FeedImageDataLoaderTask {
-			let callback: () -> Void
-			func cancel() { callback() }
-		}
-
-		func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-			messages.append((url, completion))
-			return Task { [weak self] in
-				self?.cancelledURLs.append(url)
-			}
-		}
-		
-		func complete(with error: Error, at index: Int = 0) {
-			messages[index].completion(.failure(error))
-		}
-		
-		func complete(with data: Data, at index: Int = 0) {
-			messages[index].completion(.success(data))
-		}
-	}
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -23,8 +23,10 @@ class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
 	
 	func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
 		return decoratee.loadImageData(from: url) { [weak self] result in
-			self?.cache.save((try? result.get()) ?? Data(), for: url) { _ in }
-			completion(result)
+			completion(result.map { data in
+				self?.cache.save(data, for: url) { _ in }
+				return data
+			})
 		}
 	}
 }
@@ -83,6 +85,17 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTes
 		loader.complete(with: imageData)
 
 		XCTAssertEqual(cache.messages, [.save(data: imageData, for: url)], "Expected to cache loaded image data on success")
+	}
+	
+	func test_loadImageData_doesNotCacheDataOnLoaderFailure() {
+		let cache = CacheSpy()
+		let url = anyURL()
+		let (sut, loader) = makeSUT(cache: cache)
+
+		_ = sut.loadImageData(from: url) { _ in }
+		loader.complete(with: anyNSError())
+
+		XCTAssertTrue(cache.messages.isEmpty, "Expected not to cache image data on load error")
 	}
 
 	// MARK: - Helpers

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -6,12 +6,6 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
-protocol FeedImageDataCache {
-	typealias Result = Swift.Result<Void, Error>
-
-	func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
-}
-
 class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
 	private let decoratee: FeedImageDataLoader
 	private let cache: FeedImageDataCache

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -6,25 +6,6 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
-class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
-	private let decoratee: FeedImageDataLoader
-	private let cache: FeedImageDataCache
-
-	init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
-		self.decoratee = decoratee
-		self.cache = cache
-	}
-	
-	func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-		return decoratee.loadImageData(from: url) { [weak self] result in
-			completion(result.map { data in
-				self?.cache.save(data, for: url) { _ in }
-				return data
-			})
-		}
-	}
-}
-
 class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTestCase {
 	
 	func test_init_doesNotLoadImageData() {

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -1,0 +1,127 @@
+//
+//  Copyright © 2019 Essential Developer. All rights reserved.
+//
+
+import XCTest
+import EssentialFeed
+import EssentialApp
+
+class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
+	private let decoratee: FeedImageDataLoader
+	
+	init(decoratee: FeedImageDataLoader) {
+		self.decoratee = decoratee
+	}
+	
+	func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+		return decoratee.loadImageData(from: url, completion: completion)
+	}
+}
+
+class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
+	
+	func test_init_doesNotLoadImageData() {
+		let (_, loader) = makeSUT()
+
+		XCTAssertTrue(loader.loadedURLs.isEmpty, "Expected no loaded URLs")
+	}
+	
+	func test_loadImageData_loadsFromLoader() {
+		let url = anyURL()
+		let (sut, loader) = makeSUT()
+
+		_ = sut.loadImageData(from: url) { _ in }
+		
+		XCTAssertEqual(loader.loadedURLs, [url], "Expected to load URL from loader")
+	}
+
+	func test_cancelLoadImageData_cancelsLoaderTask() {
+		let url = anyURL()
+		let (sut, loader) = makeSUT()
+
+		let task = sut.loadImageData(from: url) { _ in }
+		task.cancel()
+		
+		XCTAssertEqual(loader.cancelledURLs, [url], "Expected to cancel URL loading from loader")
+	}
+
+	func test_loadImageData_deliversDataOnLoaderSuccess() {
+		let imageData = anyData()
+		let (sut, loader) = makeSUT()
+		
+		expect(sut, toCompleteWith: .success(imageData), when: {
+			loader.complete(with: imageData)
+		})
+	}
+	
+	func test_loadImageData_deliversErrorOnLoaderFailure() {
+		let (sut, loader) = makeSUT()
+		
+		expect(sut, toCompleteWith: .failure(anyNSError()), when: {
+			loader.complete(with: anyNSError())
+		})
+	}
+
+	// MARK: - Helpers
+		
+	private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: LoaderSpy) {
+		let loader = LoaderSpy()
+		let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
+		trackForMemoryLeaks(loader, file: file, line: line)
+		trackForMemoryLeaks(sut, file: file, line: line)
+		return (sut, loader)
+	}
+	
+	private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
+		let exp = expectation(description: "Wait for load completion")
+		
+		_ = sut.loadImageData(from: anyURL()) { receivedResult in
+			switch (receivedResult, expectedResult) {
+			case let (.success(receivedFeed), .success(expectedFeed)):
+				XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+				
+			case (.failure, .failure):
+				break
+				
+			default:
+				XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+			}
+			
+			exp.fulfill()
+		}
+		
+		action()
+		
+		wait(for: [exp], timeout: 1.0)
+	}
+	
+	private class LoaderSpy: FeedImageDataLoader {
+		private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
+
+		private(set) var cancelledURLs = [URL]()
+
+		var loadedURLs: [URL] {
+			return messages.map { $0.url }
+		}
+
+		private struct Task: FeedImageDataLoaderTask {
+			let callback: () -> Void
+			func cancel() { callback() }
+		}
+
+		func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+			messages.append((url, completion))
+			return Task { [weak self] in
+				self?.cancelledURLs.append(url)
+			}
+		}
+		
+		func complete(with error: Error, at index: Int = 0) {
+			messages[index].completion(.failure(error))
+		}
+		
+		func complete(with data: Data, at index: Int = 0) {
+			messages[index].completion(.success(data))
+		}
+	}
+}

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -18,7 +18,7 @@ class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
 	}
 }
 
-class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
+class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTestCase {
 	
 	func test_init_doesNotLoadImageData() {
 		let (_, loader) = makeSUT()
@@ -71,28 +71,5 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
 		trackForMemoryLeaks(sut, file: file, line: line)
 		return (sut, loader)
 	}
-	
-	private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
-		let exp = expectation(description: "Wait for load completion")
 		
-		_ = sut.loadImageData(from: anyURL()) { receivedResult in
-			switch (receivedResult, expectedResult) {
-			case let (.success(receivedFeed), .success(expectedFeed)):
-				XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-				
-			case (.failure, .failure):
-				break
-				
-			default:
-				XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-			}
-			
-			exp.fulfill()
-		}
-		
-		action()
-		
-		wait(for: [exp], timeout: 1.0)
-	}
-	
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -6,15 +6,26 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
+protocol FeedImageDataCache {
+	typealias Result = Swift.Result<Void, Error>
+
+	func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
+}
+
 class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
 	private let decoratee: FeedImageDataLoader
-	
-	init(decoratee: FeedImageDataLoader) {
+	private let cache: FeedImageDataCache
+
+	init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
 		self.decoratee = decoratee
+		self.cache = cache
 	}
 	
 	func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-		return decoratee.loadImageData(from: url, completion: completion)
+		return decoratee.loadImageData(from: url) { [weak self] result in
+			self?.cache.save((try? result.get()) ?? Data(), for: url) { _ in }
+			completion(result)
+		}
 	}
 }
 
@@ -62,14 +73,38 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTes
 		})
 	}
 
+	func test_loadImageData_cachesLoadedDataOnLoaderSuccess() {
+		let cache = CacheSpy()
+		let url = anyURL()
+		let imageData = anyData()
+		let (sut, loader) = makeSUT(cache: cache)
+
+		_ = sut.loadImageData(from: url) { _ in }
+		loader.complete(with: imageData)
+
+		XCTAssertEqual(cache.messages, [.save(data: imageData, for: url)], "Expected to cache loaded image data on success")
+	}
+
 	// MARK: - Helpers
 		
-	private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: FeedImageDataLoaderSpy) {
+	private func makeSUT(cache: CacheSpy = .init(), file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: FeedImageDataLoaderSpy) {
 		let loader = FeedImageDataLoaderSpy()
-		let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
+		let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader, cache: cache)
 		trackForMemoryLeaks(loader, file: file, line: line)
 		trackForMemoryLeaks(sut, file: file, line: line)
 		return (sut, loader)
 	}
+
+	private class CacheSpy: FeedImageDataCache {
+		private(set) var messages = [Message]()
 		
+		enum Message: Equatable {
+			case save(data: Data, for: URL)
+		}
+		
+		func save(_ data: Data, for url: URL, completion: @escaping (FeedImageDataCache.Result) -> Void) {
+			messages.append(.save(data: data, for: url))
+			completion(.success(()))
+		}
+	}
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
@@ -6,7 +6,7 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
-class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
+class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase, FeedImageDataLoaderTestCase {
 	
 	func test_init_doesNotLoadImageData() {
 		let (_, primaryLoader, fallbackLoader) = makeSUT()
@@ -98,29 +98,6 @@ class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
 		trackForMemoryLeaks(fallbackLoader, file: file, line: line)
 		trackForMemoryLeaks(sut, file: file, line: line)
 		return (sut, primaryLoader, fallbackLoader)
-	}
-	
-	private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
-		let exp = expectation(description: "Wait for load completion")
-		
-		_ = sut.loadImageData(from: anyURL()) { receivedResult in
-			switch (receivedResult, expectedResult) {
-			case let (.success(receivedFeed), .success(expectedFeed)):
-				XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-				
-			case (.failure, .failure):
-				break
-				
-			default:
-				XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-			}
-			
-			exp.fulfill()
-		}
-		
-		action()
-		
-		wait(for: [exp], timeout: 1.0)
 	}
 		
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
@@ -90,9 +90,9 @@ class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
 
 	// MARK: - Helpers
 	
-	private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, primary: LoaderSpy, fallback: LoaderSpy) {
-		let primaryLoader = LoaderSpy()
-		let fallbackLoader = LoaderSpy()
+	private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, primary: FeedImageDataLoaderSpy, fallback: FeedImageDataLoaderSpy) {
+		let primaryLoader = FeedImageDataLoaderSpy()
+		let fallbackLoader = FeedImageDataLoaderSpy()
 		let sut = FeedImageDataLoaderWithFallbackComposite(primary: primaryLoader, fallback: fallbackLoader)
 		trackForMemoryLeaks(primaryLoader, file: file, line: line)
 		trackForMemoryLeaks(fallbackLoader, file: file, line: line)
@@ -122,35 +122,5 @@ class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
 		
 		wait(for: [exp], timeout: 1.0)
 	}
-	
-	private class LoaderSpy: FeedImageDataLoader {
-		private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
-
-		private(set) var cancelledURLs = [URL]()
-
-		var loadedURLs: [URL] {
-			return messages.map { $0.url }
-		}
-
-		private struct Task: FeedImageDataLoaderTask {
-			let callback: () -> Void
-			func cancel() { callback() }
-		}
-
-		func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-			messages.append((url, completion))
-			return Task { [weak self] in
-				self?.cancelledURLs.append(url)
-			}
-		}
 		
-		func complete(with error: Error, at index: Int = 0) {
-			messages[index].completion(.failure(error))
-		}
-		
-		func complete(with data: Data, at index: Int = 0) {
-			messages[index].completion(.success(data))
-		}
-	}
-	
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -5,15 +5,26 @@
 import XCTest
 import EssentialFeed
 
+protocol FeedCache {
+	typealias Result = Swift.Result<Void, Error>
+
+	func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
+}
+
 final class FeedLoaderCacheDecorator: FeedLoader {
 	private let decoratee: FeedLoader
+	private let cache: FeedCache
 	
-	init(decoratee: FeedLoader) {
+	init(decoratee: FeedLoader, cache: FeedCache) {
 		self.decoratee = decoratee
+		self.cache = cache
 	}
 	
 	func load(completion: @escaping (FeedLoader.Result) -> Void) {
-		decoratee.load(completion: completion)
+		decoratee.load { [weak self] result in
+			self?.cache.save((try? result.get()) ?? []) { _ in }
+			completion(result)
+		}
 	}
 }
 
@@ -32,14 +43,37 @@ class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
 		expect(sut, toCompleteWith: .failure(anyNSError()))
 	}
 	
+	func test_load_cachesLoadedFeedOnLoaderSuccess() {
+		let cache = CacheSpy()
+		let feed = uniqueFeed()
+		let sut = makeSUT(loaderResult: .success(feed), cache: cache)
+
+		sut.load { _ in }
+		
+		XCTAssertEqual(cache.messages, [.save(feed)], "Expected to cache loaded feed on success")
+	}
+	
 	// MARK: - Helpers
 	
-	private func makeSUT(loaderResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
+	private func makeSUT(loaderResult: FeedLoader.Result, cache: CacheSpy = .init(), file: StaticString = #file, line: UInt = #line) -> FeedLoader {
 		let loader = FeedLoaderStub(result: loaderResult)
-		let sut = FeedLoaderCacheDecorator(decoratee: loader)
+		let sut = FeedLoaderCacheDecorator(decoratee: loader, cache: cache)
 		trackForMemoryLeaks(loader, file: file, line: line)
 		trackForMemoryLeaks(sut, file: file, line: line)
 		return sut
+	}
+	
+	private class CacheSpy: FeedCache {
+		private(set) var messages = [Message]()
+		
+		enum Message: Equatable {
+			case save([FeedImage])
+		}
+		
+		func save(_ feed: [FeedImage], completion: @escaping (FeedCache.Result) -> Void) {
+			messages.append(.save(feed))
+			completion(.success(()))
+		}
 	}
 	
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -1,0 +1,77 @@
+//
+//  Copyright © 2019 Essential Developer. All rights reserved.
+//
+
+import XCTest
+import EssentialFeed
+
+final class FeedLoaderCacheDecorator: FeedLoader {
+	private let decoratee: FeedLoader
+	
+	init(decoratee: FeedLoader) {
+		self.decoratee = decoratee
+	}
+	
+	func load(completion: @escaping (FeedLoader.Result) -> Void) {
+		decoratee.load(completion: completion)
+	}
+}
+
+class FeedLoaderCacheDecoratorTests: XCTestCase {
+
+	func test_load_deliversFeedOnLoaderSuccess() {
+		let feed = uniqueFeed()
+		let loader = LoaderStub(result: .success(feed))
+		let sut = FeedLoaderCacheDecorator(decoratee: loader)
+		
+		expect(sut, toCompleteWith: .success(feed))
+	}
+	
+	func test_load_deliversErrorOnLoaderFailure() {
+		let loader = LoaderStub(result: .failure(anyNSError()))
+		let sut = FeedLoaderCacheDecorator(decoratee: loader)
+		
+		expect(sut, toCompleteWith: .failure(anyNSError()))
+	}
+	
+	// MARK: - Helpers
+	
+	private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
+		let exp = expectation(description: "Wait for load completion")
+		
+		sut.load { receivedResult in
+			switch (receivedResult, expectedResult) {
+			case let (.success(receivedFeed), .success(expectedFeed)):
+				XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+				
+			case (.failure, .failure):
+				break
+				
+			default:
+				XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+			}
+			
+			exp.fulfill()
+		}
+				
+		wait(for: [exp], timeout: 1.0)
+	}
+	
+	private func uniqueFeed() -> [FeedImage] {
+		return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
+	}
+
+	private class LoaderStub: FeedLoader {
+		private let result: FeedLoader.Result
+		
+		init(result: FeedLoader.Result) {
+			self.result = result
+		}
+
+		func load(completion: @escaping (FeedLoader.Result) -> Void) {
+			completion(result)
+		}
+	}
+
+	
+}

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -57,8 +57,4 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
 		wait(for: [exp], timeout: 1.0)
 	}
 	
-	private func uniqueFeed() -> [FeedImage] {
-		return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
-	}
-	
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -5,12 +5,6 @@
 import XCTest
 import EssentialFeed
 
-protocol FeedCache {
-	typealias Result = Swift.Result<Void, Error>
-
-	func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
-}
-
 final class FeedLoaderCacheDecorator: FeedLoader {
 	private let decoratee: FeedLoader
 	private let cache: FeedCache

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -4,25 +4,7 @@
 
 import XCTest
 import EssentialFeed
-
-final class FeedLoaderCacheDecorator: FeedLoader {
-	private let decoratee: FeedLoader
-	private let cache: FeedCache
-	
-	init(decoratee: FeedLoader, cache: FeedCache) {
-		self.decoratee = decoratee
-		self.cache = cache
-	}
-	
-	func load(completion: @escaping (FeedLoader.Result) -> Void) {
-		decoratee.load { [weak self] result in
-			completion(result.map { feed in
-				self?.cache.save(feed) { _ in }
-				return feed
-			})
-		}
-	}
-}
+import EssentialApp
 
 class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
 

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -22,7 +22,9 @@ final class FeedLoaderCacheDecorator: FeedLoader {
 	
 	func load(completion: @escaping (FeedLoader.Result) -> Void) {
 		decoratee.load { [weak self] result in
-			self?.cache.save((try? result.get()) ?? []) { _ in }
+			if let feed = try? result.get() {
+				self?.cache.save(feed) { _ in }
+			}
 			completion(result)
 		}
 	}
@@ -51,6 +53,15 @@ class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
 		sut.load { _ in }
 		
 		XCTAssertEqual(cache.messages, [.save(feed)], "Expected to cache loaded feed on success")
+	}
+	
+	func test_load_doesNotCacheOnLoaderFailure() {
+		let cache = CacheSpy()
+		let sut = makeSUT(loaderResult: .failure(anyNSError()), cache: cache)
+
+		sut.load { _ in }
+
+		XCTAssertTrue(cache.messages.isEmpty, "Expected not to cache feed on load error")
 	}
 	
 	// MARK: - Helpers

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -17,7 +17,7 @@ final class FeedLoaderCacheDecorator: FeedLoader {
 	}
 }
 
-class FeedLoaderCacheDecoratorTests: XCTestCase {
+class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
 
 	func test_load_deliversFeedOnLoaderSuccess() {
 		let feed = uniqueFeed()
@@ -32,29 +32,6 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
 		let sut = FeedLoaderCacheDecorator(decoratee: loader)
 		
 		expect(sut, toCompleteWith: .failure(anyNSError()))
-	}
-	
-	// MARK: - Helpers
-	
-	private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
-		let exp = expectation(description: "Wait for load completion")
-		
-		sut.load { receivedResult in
-			switch (receivedResult, expectedResult) {
-			case let (.success(receivedFeed), .success(expectedFeed)):
-				XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-				
-			case (.failure, .failure):
-				break
-				
-			default:
-				XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-			}
-			
-			exp.fulfill()
-		}
-				
-		wait(for: [exp], timeout: 1.0)
 	}
 	
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -21,14 +21,14 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
 
 	func test_load_deliversFeedOnLoaderSuccess() {
 		let feed = uniqueFeed()
-		let loader = LoaderStub(result: .success(feed))
+		let loader = FeedLoaderStub(result: .success(feed))
 		let sut = FeedLoaderCacheDecorator(decoratee: loader)
 		
 		expect(sut, toCompleteWith: .success(feed))
 	}
 	
 	func test_load_deliversErrorOnLoaderFailure() {
-		let loader = LoaderStub(result: .failure(anyNSError()))
+		let loader = FeedLoaderStub(result: .failure(anyNSError()))
 		let sut = FeedLoaderCacheDecorator(decoratee: loader)
 		
 		expect(sut, toCompleteWith: .failure(anyNSError()))
@@ -60,18 +60,5 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
 	private func uniqueFeed() -> [FeedImage] {
 		return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
 	}
-
-	private class LoaderStub: FeedLoader {
-		private let result: FeedLoader.Result
-		
-		init(result: FeedLoader.Result) {
-			self.result = result
-		}
-
-		func load(completion: @escaping (FeedLoader.Result) -> Void) {
-			completion(result)
-		}
-	}
-
 	
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -22,10 +22,10 @@ final class FeedLoaderCacheDecorator: FeedLoader {
 	
 	func load(completion: @escaping (FeedLoader.Result) -> Void) {
 		decoratee.load { [weak self] result in
-			if let feed = try? result.get() {
+			completion(result.map { feed in
 				self?.cache.save(feed) { _ in }
-			}
-			completion(result)
+				return feed
+			})
 		}
 	}
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -21,17 +21,25 @@ class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
 
 	func test_load_deliversFeedOnLoaderSuccess() {
 		let feed = uniqueFeed()
-		let loader = FeedLoaderStub(result: .success(feed))
-		let sut = FeedLoaderCacheDecorator(decoratee: loader)
-		
+		let sut = makeSUT(loaderResult: .success(feed))
+
 		expect(sut, toCompleteWith: .success(feed))
 	}
 	
 	func test_load_deliversErrorOnLoaderFailure() {
-		let loader = FeedLoaderStub(result: .failure(anyNSError()))
-		let sut = FeedLoaderCacheDecorator(decoratee: loader)
-		
+		let sut = makeSUT(loaderResult: .failure(anyNSError()))
+
 		expect(sut, toCompleteWith: .failure(anyNSError()))
+	}
+	
+	// MARK: - Helpers
+	
+	private func makeSUT(loaderResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
+		let loader = FeedLoaderStub(result: loaderResult)
+		let sut = FeedLoaderCacheDecorator(decoratee: loader)
+		trackForMemoryLeaks(loader, file: file, line: line)
+		trackForMemoryLeaks(sut, file: file, line: line)
+		return sut
 	}
 	
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -32,8 +32,8 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
 	// MARK: - Helpers
 	
 	private func makeSUT(primaryResult: FeedLoader.Result, fallbackResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
-		let primaryLoader = LoaderStub(result: primaryResult)
-		let fallbackLoader = LoaderStub(result: fallbackResult)
+		let primaryLoader = FeedLoaderStub(result: primaryResult)
+		let fallbackLoader = FeedLoaderStub(result: fallbackResult)
 		let sut = FeedLoaderWithFallbackComposite(primary: primaryLoader, fallback: fallbackLoader)
 		trackForMemoryLeaks(primaryLoader, file: file, line: line)
 		trackForMemoryLeaks(fallbackLoader, file: file, line: line)
@@ -64,18 +64,6 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
 	
 	private func uniqueFeed() -> [FeedImage] {
 		return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
-	}
-
-	private class LoaderStub: FeedLoader {
-		private let result: FeedLoader.Result
-		
-		init(result: FeedLoader.Result) {
-			self.result = result
-		}
-
-		func load(completion: @escaping (FeedLoader.Result) -> Void) {
-			completion(result)
-		}
 	}
 
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -61,9 +61,5 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
 				
 		wait(for: [exp], timeout: 1.0)
 	}
-	
-	private func uniqueFeed() -> [FeedImage] {
-		return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
-	}
 
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -6,7 +6,7 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
-class FeedLoaderWithFallbackCompositeTests: XCTestCase {
+class FeedLoaderWithFallbackCompositeTests: XCTestCase, FeedLoaderTestCase {
 	
 	func test_load_deliversPrimaryFeedOnPrimaryLoaderSuccess() {
 		let primaryFeed = uniqueFeed()
@@ -39,27 +39,6 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
 		trackForMemoryLeaks(fallbackLoader, file: file, line: line)
 		trackForMemoryLeaks(sut, file: file, line: line)
 		return sut
-	}
-
-	private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
-		let exp = expectation(description: "Wait for load completion")
-		
-		sut.load { receivedResult in
-			switch (receivedResult, expectedResult) {
-			case let (.success(receivedFeed), .success(expectedFeed)):
-				XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-				
-			case (.failure, .failure):
-				break
-				
-			default:
-				XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-			}
-			
-			exp.fulfill()
-		}
-				
-		wait(for: [exp], timeout: 1.0)
 	}
 
 }

--- a/EssentialApp/EssentialAppTests/Helpers/FeedImageDataLoaderSpy.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedImageDataLoaderSpy.swift
@@ -1,0 +1,36 @@
+//
+//  Copyright © 2019 Essential Developer. All rights reserved.
+//
+
+import Foundation
+import EssentialFeed
+
+class FeedImageDataLoaderSpy: FeedImageDataLoader {
+	private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
+
+	private(set) var cancelledURLs = [URL]()
+
+	var loadedURLs: [URL] {
+		return messages.map { $0.url }
+	}
+
+	private struct Task: FeedImageDataLoaderTask {
+		let callback: () -> Void
+		func cancel() { callback() }
+	}
+
+	func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+		messages.append((url, completion))
+		return Task { [weak self] in
+			self?.cancelledURLs.append(url)
+		}
+	}
+	
+	func complete(with error: Error, at index: Int = 0) {
+		messages[index].completion(.failure(error))
+	}
+	
+	func complete(with data: Data, at index: Int = 0) {
+		messages[index].completion(.success(data))
+	}
+}

--- a/EssentialApp/EssentialAppTests/Helpers/FeedLoaderStub.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedLoaderStub.swift
@@ -1,0 +1,17 @@
+//
+//  Copyright © 2019 Essential Developer. All rights reserved.
+//
+
+import EssentialFeed
+
+class FeedLoaderStub: FeedLoader {
+	private let result: FeedLoader.Result
+	
+	init(result: FeedLoader.Result) {
+		self.result = result
+	}
+
+	func load(completion: @escaping (FeedLoader.Result) -> Void) {
+		completion(result)
+	}
+}

--- a/EssentialApp/EssentialAppTests/Helpers/SharedTestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/SharedTestHelpers.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import EssentialFeed
 
 func anyNSError() -> NSError {
 	return NSError(domain: "any error", code: 0)
@@ -14,4 +15,8 @@ func anyURL() -> URL {
 
 func anyData() -> Data {
 	return Data("any data".utf8)
+}
+
+func uniqueFeed() -> [FeedImage] {
+	return [FeedImage(id: UUID(), description: "any", location: "any", url: anyURL())]
 }

--- a/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedImageDataLoader.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedImageDataLoader.swift
@@ -1,0 +1,33 @@
+//
+//  Copyright © 2019 Essential Developer. All rights reserved.
+//
+
+import XCTest
+import EssentialFeed
+
+protocol FeedImageDataLoaderTestCase: XCTestCase {}
+
+extension FeedImageDataLoaderTestCase {
+	func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
+		let exp = expectation(description: "Wait for load completion")
+		
+		_ = sut.loadImageData(from: anyURL()) { receivedResult in
+			switch (receivedResult, expectedResult) {
+			case let (.success(receivedFeed), .success(expectedFeed)):
+				XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+				
+			case (.failure, .failure):
+				break
+				
+			default:
+				XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+			}
+			
+			exp.fulfill()
+		}
+		
+		action()
+		
+		wait(for: [exp], timeout: 1.0)
+	}
+}

--- a/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedLoader.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedLoader.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright © 2019 Essential Developer. All rights reserved.
+//
+
+import XCTest
+import EssentialFeed
+
+protocol FeedLoaderTestCase: XCTestCase {}
+
+extension FeedLoaderTestCase {
+	func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
+		let exp = expectation(description: "Wait for load completion")
+		
+		sut.load { receivedResult in
+			switch (receivedResult, expectedResult) {
+			case let (.success(receivedFeed), .success(expectedFeed)):
+				XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+				
+			case (.failure, .failure):
+				break
+				
+			default:
+				XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+			}
+			
+			exp.fulfill()
+		}
+				
+		wait(for: [exp], timeout: 1.0)
+	}
+}

--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0804862E236345A40087ED48 /* FeedImageDataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0804862D236345A40087ED48 /* FeedImageDataCache.swift */; };
 		080EDEFB21B6DA7E00813479 /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 080EDEF121B6DA7E00813479 /* EssentialFeed.framework */; };
 		080EDF0C21B6DAE800813479 /* FeedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080EDF0B21B6DAE800813479 /* FeedImage.swift */; };
 		080EDF0E21B6DCB600813479 /* FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080EDF0D21B6DCB600813479 /* FeedLoader.swift */; };
@@ -135,6 +136,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0804862D236345A40087ED48 /* FeedImageDataCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataCache.swift; sourceTree = "<group>"; };
 		080EDEF121B6DA7E00813479 /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		080EDEF521B6DA7E00813479 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		080EDEFA21B6DA7E00813479 /* EssentialFeedTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialFeedTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -345,6 +347,7 @@
 				080EDF0D21B6DCB600813479 /* FeedLoader.swift */,
 				08F8822C236499B200CAEE16 /* FeedCache.swift */,
 				08FC5AA922D5F47900148E12 /* FeedImageDataLoader.swift */,
+				0804862D236345A40087ED48 /* FeedImageDataCache.swift */,
 			);
 			path = "Feed Feature";
 			sourceTree = "<group>";
@@ -880,6 +883,7 @@
 				089C40DC22170EC500DE552E /* LocalFeedLoader.swift in Sources */,
 				08C0880C21E4EED600ACFB30 /* HTTPClient.swift in Sources */,
 				080EDF0C21B6DAE800813479 /* FeedImage.swift in Sources */,
+				0804862E236345A40087ED48 /* FeedImageDataCache.swift in Sources */,
 				08C4E988233E13CC00D939F8 /* FeedImageDataStore.swift in Sources */,
 				087148B6232BEAAF00D6BE1A /* FeedPresenter.swift in Sources */,
 				0844769121FCBE7D00439BE9 /* URLSessionHTTPClient.swift in Sources */,

--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		08EFB83722D4A74900A46837 /* FeedUIIntegrationTests+Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EFB83622D4A74900A46837 /* FeedUIIntegrationTests+Assertions.swift */; };
 		08EFE6BD22D6384100DA417A /* FeedImageCellController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EFE6BC22D6384100DA417A /* FeedImageCellController.swift */; };
 		08EFE6C022D63E8D00DA417A /* FeedUIComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08EFE6BF22D63E8D00DA417A /* FeedUIComposer.swift */; };
+		08F8822D236499B200CAEE16 /* FeedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F8822C236499B200CAEE16 /* FeedCache.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -231,6 +232,7 @@
 		08EFB83622D4A74900A46837 /* FeedUIIntegrationTests+Assertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedUIIntegrationTests+Assertions.swift"; sourceTree = "<group>"; };
 		08EFE6BC22D6384100DA417A /* FeedImageCellController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageCellController.swift; sourceTree = "<group>"; };
 		08EFE6BF22D63E8D00DA417A /* FeedUIComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedUIComposer.swift; sourceTree = "<group>"; };
+		08F8822C236499B200CAEE16 /* FeedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCache.swift; sourceTree = "<group>"; };
 		08FC5AA922D5F47900148E12 /* FeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoader.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -341,6 +343,7 @@
 			children = (
 				080EDF0B21B6DAE800813479 /* FeedImage.swift */,
 				080EDF0D21B6DCB600813479 /* FeedLoader.swift */,
+				08F8822C236499B200CAEE16 /* FeedCache.swift */,
 				08FC5AA922D5F47900148E12 /* FeedImageDataLoader.swift */,
 			);
 			path = "Feed Feature";
@@ -888,6 +891,7 @@
 				087148BB232BEC1200D6BE1A /* FeedLoadingViewModel.swift in Sources */,
 				08604503233E2917005ECD22 /* CoreDataFeedStore+FeedImageDataLoader.swift in Sources */,
 				087148C2232BFC7100D6BE1A /* FeedImagePresenter.swift in Sources */,
+				08F8822D236499B200CAEE16 /* FeedCache.swift in Sources */,
 				08285AFF228C1874000A8987 /* ManagedFeedImage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedImageDataLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedImageDataLoader.swift
@@ -12,8 +12,8 @@ public final class LocalFeedImageDataLoader {
 	}
 }
 
-extension LocalFeedImageDataLoader {
-	public typealias SaveResult = Result<Void, Error>
+extension LocalFeedImageDataLoader: FeedImageDataCache {
+	public typealias SaveResult = FeedImageDataCache.Result
 
 	public enum SaveError: Error {
 		case failed

--- a/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -14,8 +14,8 @@ public final class LocalFeedLoader {
 	}
 }
 
-extension LocalFeedLoader {
-	public typealias SaveResult = Result<Void, Error>
+extension LocalFeedLoader: FeedCache {
+	public typealias SaveResult = FeedCache.Result
 
 	public func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void) {
 		store.deleteCachedFeed { [weak self] deletionResult in

--- a/EssentialFeed/EssentialFeed/Feed Feature/FeedCache.swift
+++ b/EssentialFeed/EssentialFeed/Feed Feature/FeedCache.swift
@@ -1,0 +1,11 @@
+//
+//  Copyright © 2019 Essential Developer. All rights reserved.
+//
+
+import Foundation
+
+public protocol FeedCache {
+	typealias Result = Swift.Result<Void, Error>
+
+	func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
+}

--- a/EssentialFeed/EssentialFeed/Feed Feature/FeedImageDataCache.swift
+++ b/EssentialFeed/EssentialFeed/Feed Feature/FeedImageDataCache.swift
@@ -1,0 +1,11 @@
+//
+//  Copyright © 2019 Essential Developer. All rights reserved.
+//
+
+import Foundation
+
+public protocol FeedImageDataCache {
+	typealias Result = Swift.Result<Void, Error>
+
+	func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
+}


### PR DESCRIPTION
Added `[*]LoaderCacheDecorator`s responsible for decorating (intercepting) `load` operations and injecting the `save` side-effect on successful load results.

We can now use the decorators to compose the `RemoteFeedLoader.load`with the `LocalFeedLoader.save` operations in a simple, clean, extendable, modular, and testable way.