### PR TITLE
Fix tuple pattern warning related with xcode upgrade to 11.4

### DIFF
--- a/EssentialFeed/EssentialFeed/Feed API/RemoteFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/Feed API/RemoteFeedLoader.swift
@@ -25,7 +25,7 @@ public final class RemoteFeedLoader: FeedLoader {
 			guard self != nil else { return }
 			
 			switch result {
-			case let .success(data, response):
+			case let .success((data, response)):
 				completion(RemoteFeedLoader.map(data, from: response))
 				
 			case .failure:

--- a/EssentialFeed/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
@@ -92,8 +92,8 @@ class URLSessionHTTPClientTests: XCTestCase {
 		let result = resultFor(values, file: file, line: line)
 
 		switch result {
-		case let .success(successResult):
-			return successResult
+		case let .success(values):
+			return values
 		default:
 			XCTFail("Expected success, got \(result) instead", file: file, line: line)
 			return nil

--- a/EssentialFeed/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed API/URLSessionHTTPClientTests.swift
@@ -92,8 +92,8 @@ class URLSessionHTTPClientTests: XCTestCase {
 		let result = resultFor(values, file: file, line: line)
 
 		switch result {
-		case let .success(data, response):
-			return (data, response)
+		case let .success(successResult):
+			return successResult
 		default:
 			XCTFail("Expected success, got \(result) instead", file: file, line: line)
 			return nil


### PR DESCRIPTION
This warning appears after upgrading to Xcode 11.4 

https://developer.apple.com/documentation/xcode_release_notes/xcode_11_4_release_notes

`Code that relies on the compiler automatically tupling a pattern may lead to a compiler error when upgrading to Xcode 11.4, even though the code compiled before. (58425942)`