### PR TITLE
Make a static property `storeURL` for the default store URL

### DIFF
--- a/EssentialApp/EssentialApp/SceneDelegate.swift
+++ b/EssentialApp/EssentialApp/SceneDelegate.swift
@@ -3,7 +3,6 @@
 //
 
 import UIKit
-import CoreData
 import EssentialFeed
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -14,10 +13,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 	}()
 	
 	private lazy var store: FeedStore & FeedImageDataStore = {
-		try! CoreDataFeedStore(
-			storeURL: NSPersistentContainer
-				.defaultDirectoryURL()
-				.appendingPathComponent("feed-store.sqlite"))
+        try! CoreDataFeedStore(storeURL: CoreDataFeedStore.storeURL)
 	}()
 
 	private lazy var localFeedLoader: LocalFeedLoader = {

--- a/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
+++ b/EssentialFeed/EssentialFeed/Feed Cache/Infrastructure/CoreData/CoreDataFeedStore.swift
@@ -5,6 +5,8 @@
 import CoreData
 
 public final class CoreDataFeedStore {
+    public static let storeURL = NSPersistentContainer.defaultDirectoryURL()
+    .appendingPathComponent("feed-store.sqlite")
 	private static let modelName = "FeedStore"
 	private static let model = NSManagedObjectModel.with(name: modelName, in: Bundle(for: CoreDataFeedStore.self))
 	


### PR DESCRIPTION
Just an idea for the storeURL to be declared in the CoreData infrastructure scope. 
Maybe an idea not to import `CoreData` in the `SceneDelegate`, although Main can import anything. What do you think? Is this a thing to consider?
