### PR TITLE
add attachments to the failing snapshot tests

### DIFF
--- a/EssentialFeed/EssentialFeediOSTests/Helpers/XCTestCase+Snapshot.swift
+++ b/EssentialFeed/EssentialFeediOSTests/Helpers/XCTestCase+Snapshot.swift
@@ -21,6 +21,11 @@ extension XCTestCase {
 			
 			try? snapshotData?.write(to: temporarySnapshotURL)
 			
+			add(makeSnapshotAttachment(for: snapshot, named: "New snapshot - \(name)"))
+			if let storedSnapshot = UIImage(data: storedSnapshotData) {
+				add(makeSnapshotAttachment(for: storedSnapshot, named: "Stored snapshot - \(name)"))
+			}
+			
 			XCTFail("New snapshot does not match stored snapshot. New snapshot URL: \(temporarySnapshotURL), Stored snapshot URL: \(snapshotURL)", file: file, line: line)
 		}
 	}
@@ -56,6 +61,12 @@ extension XCTestCase {
 		}
 		
 		return data
+	}
+	
+	private func makeSnapshotAttachment(for snapshot: UIImage, named name: String) -> XCTAttachment {
+		let attachment = XCTAttachment(image: snapshot)
+		attachment.name = name
+		return attachment
 	}
 	
 }


### PR DESCRIPTION
![Screenshot 2021-12-11 at 14 33 35](https://user-images.githubusercontent.com/9988884/145678646-235206fb-cd22-4a54-b90d-657b172c5d17.png)

This makes it a little bit easier to see the failing & stored snapshots when the test fails