### PR TITLE
Update property name to match sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Given the customer doesn't have connectivity
 | `id`          | `UUID`              |
 | `description` | `String` (optional) |
 | `location`    | `String` (optional) |
-| `url`	        | `URL`               |
+| `image`       | `URL`               |
 
 ### Payload contract
 


### PR DESCRIPTION
The property name was accidentally set to `url`, which is the property's type. The property name should be `image` as it is shown in the sample data.