### PR TITLE
Fix for iOS 14.5 prefetching behavior change

### DIFF
--- a/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -434,6 +434,27 @@ class FeedUIIntegrationTests: XCTestCase {
 		XCTAssertEqual(loader.cancelledImageURLs, [image0.url, image1.url], "Expected second cancelled image URL request once second image is not near visible anymore")
 	}
 	
+	func test_feedImageView_configuresViewCorrectlyWhenTransitioningFromNearVisibleToVisibleWhileStillPreloadingImage() {
+		let (sut, loader) = makeSUT()
+		
+		sut.loadViewIfNeeded()
+		loader.completeFeedLoading(with: [makeImage()])
+		
+		sut.simulateFeedImageViewNearVisible(at: 0)
+		let view0 = sut.simulateFeedImageViewVisible(at: 0)
+		
+		XCTAssertEqual(view0?.renderedImage, nil, "Expected no rendered image when view becomes visible while still preloading image")
+		XCTAssertEqual(view0?.isShowingRetryAction, false, "Expected no retry action when view becomes visible while still preloading image")
+		XCTAssertEqual(view0?.isShowingImageLoadingIndicator, true, "Expected loading indicator when view becomes visible while still preloading image")
+		
+		let imageData = UIImage.make(withColor: .red).pngData()!
+		loader.completeImageLoading(with: imageData, at: 0)
+		
+		XCTAssertEqual(view0?.renderedImage, imageData, "Expected rendered image after image preloads successfully")
+		XCTAssertEqual(view0?.isShowingRetryAction, false, "Expected no retry action after image preloads successfully")
+		XCTAssertEqual(view0?.isShowingImageLoadingIndicator, false, "Expected no loading indicator after image preloads successfully")
+	}
+	
 	func test_feedImageView_doesNotRenderLoadedImageWhenNotVisibleAnymore() {
 		let (sut, loader) = makeSUT()
 		sut.loadViewIfNeeded()

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
@@ -37,6 +37,8 @@ extension FeedImageCellController: UITableViewDataSource, UITableViewDelegate, U
 		cell?.locationLabel.text = viewModel.location
 		cell?.descriptionLabel.text = viewModel.description
 		cell?.feedImageView.image = nil
+		cell?.feedImageContainer.isShimmering = true
+		cell?.feedImageRetryButton.isHidden = true
 		cell?.onRetry = { [weak self] in
 			self?.delegate.didRequestImage()
 		}


### PR DESCRIPTION
Ensure the reusable cells are reset correctly on `cellForRowAt` data source method because prefetching is more likely to start at the same time cells will become visible on iOS 14.5+ (and it could lead to race conditions in the cell configuration).