### PR TITLE
Fix for iOS 15 cell lifecycle behavior change

### DIFF
--- a/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -294,6 +294,23 @@ class FeedUIIntegrationTests: XCTestCase {
 		XCTAssertEqual(loader.cancelledImageURLs, [image0.url, image1.url], "Expected two cancelled image URL requests once second image is also not visible anymore")
 	}
 	
+	func test_feedImageView_reloadsImageURLWhenBecomingVisibleAgain() {
+		let image0 = makeImage(url: URL(string: "http://url-0.com")!)
+		let image1 = makeImage(url: URL(string: "http://url-1.com")!)
+		let (sut, loader) = makeSUT()
+		
+		sut.loadViewIfNeeded()
+		loader.completeFeedLoading(with: [image0, image1])
+
+		sut.simulateFeedImageBecomingVisibleAgain(at: 0)
+		
+		XCTAssertEqual(loader.loadedImageURLs, [image0.url, image0.url], "Expected two image URL request after first view becomes visible again")
+		
+		sut.simulateFeedImageBecomingVisibleAgain(at: 1)
+
+		XCTAssertEqual(loader.loadedImageURLs, [image0.url, image0.url, image1.url, image1.url], "Expected two new image URL request after second view becomes visible again")
+	}
+	
 	func test_feedImageViewLoadingIndicator_isVisibleWhileLoadingImage() {
 		let (sut, loader) = makeSUT()
 		
@@ -453,6 +470,26 @@ class FeedUIIntegrationTests: XCTestCase {
 		XCTAssertEqual(view0?.renderedImage, imageData, "Expected rendered image after image preloads successfully")
 		XCTAssertEqual(view0?.isShowingRetryAction, false, "Expected no retry action after image preloads successfully")
 		XCTAssertEqual(view0?.isShowingImageLoadingIndicator, false, "Expected no loading indicator after image preloads successfully")
+	}
+	
+	func test_feedImageView_configuresViewCorrectlyWhenCellBecomingVisibleAgain() {
+		let (sut, loader) = makeSUT()
+		
+		sut.loadViewIfNeeded()
+		loader.completeFeedLoading(with: [makeImage()])
+		
+		let view0 = sut.simulateFeedImageBecomingVisibleAgain(at: 0)
+		
+		XCTAssertEqual(view0?.renderedImage, nil, "Expected no rendered image when view becomes visible again")
+		XCTAssertEqual(view0?.isShowingRetryAction, false, "Expected no retry action when view becomes visible again")
+		XCTAssertEqual(view0?.isShowingImageLoadingIndicator, true, "Expected loading indicator when view becomes visible again")
+		
+		let imageData = UIImage.make(withColor: .red).pngData()!
+		loader.completeImageLoading(with: imageData, at: 1)
+		
+		XCTAssertEqual(view0?.renderedImage, imageData, "Expected rendered image when image loads successfully after view becomes visible again")
+		XCTAssertEqual(view0?.isShowingRetryAction, false, "Expected no retry when image loads successfully after view becomes visible again")
+		XCTAssertEqual(view0?.isShowingImageLoadingIndicator, false, "Expected no loading indicator when image loads successfully after view becomes visible again")
 	}
 	
 	func test_feedImageView_doesNotRenderLoadedImageWhenNotVisibleAnymore() {

--- a/EssentialApp/EssentialAppTests/Helpers/ListViewController+TestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/ListViewController+TestHelpers.swift
@@ -74,6 +74,17 @@ extension ListViewController {
 	}
 	
 	@discardableResult
+	func simulateFeedImageBecomingVisibleAgain(at row: Int) -> FeedImageCell? {
+		let view = simulateFeedImageViewNotVisible(at: row)
+		
+		let delegate = tableView.delegate
+		let index = IndexPath(row: row, section: feedImagesSection)
+		delegate?.tableView?(tableView, willDisplay: view!, forRowAt: index)
+		
+		return view
+	}
+	
+	@discardableResult
 	func simulateFeedImageViewNotVisible(at row: Int) -> FeedImageCell? {
 		let view = simulateFeedImageViewVisible(at: row)
 		

--- a/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
+++ b/EssentialFeed/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
@@ -50,6 +50,11 @@ extension FeedImageCellController: UITableViewDataSource, UITableViewDelegate, U
 		selection()
 	}
 	
+	public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+		self.cell = cell as? FeedImageCell
+		delegate.didRequestImage()
+	}
+	
 	public func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
 		cancelLoad()
 	}


### PR DESCRIPTION
Capture cell reference and load/reload cell resources on `willDisplayCell` as a fix for iOS 15 cell prefetching behavior change. 

Background: On iOS 15+, for performance reasons, the table view data source may not recreate a cell using the `cellForRow` method if there's a cached cell for the given IndexPath. In this case, it'll just call `willDisplayCell`. However, we release a reference of the cell and cancel requests on `didEndDisplayingCell`. 

So, since `cellForRow` may not be called anymore, we need to implement `willDisplayCell` to know when the cached cell is becoming visible again to recapture a reference of the cell and load/reload any resource needed for the cell.