### PR TITLE
Use built-in Result initializer to simplify Result mapping

### DIFF
--- a/EssentialFeed/EssentialFeedAPIEndToEndTests/EssentialFeedAPIEndToEndTests.swift
+++ b/EssentialFeed/EssentialFeedAPIEndToEndTests/EssentialFeedAPIEndToEndTests.swift
@@ -50,11 +50,7 @@ class EssentialFeedAPIEndToEndTests: XCTestCase {
 		var receivedResult: Swift.Result<[FeedImage], Error>?
 		client.get(from: feedTestServerURL) { result in
 			receivedResult = result.flatMap { (data, response) in
-				do {
-					return .success(try FeedItemsMapper.map(data, from: response))
-				} catch {
-					return .failure(error)
-				}
+				Result { try FeedItemsMapper.map(data, from: response) }
 			}
 			exp.fulfill()
 		}
@@ -71,11 +67,7 @@ class EssentialFeedAPIEndToEndTests: XCTestCase {
 		var receivedResult: Result<Data, Error>?
 		client.get(from: url) { result in
 			receivedResult = result.flatMap { (data, response) in
-				do {
-					return .success(try FeedImageDataMapper.map(data, from: response))
-				} catch {
-					return .failure(error)
-				}
+				Result { try FeedImageDataMapper.map(data, from: response) }
 			}
 			exp.fulfill()
 		}


### PR DESCRIPTION
I would suggest using `Result { ... }` instead of performing the mapping via `do-catch` manually. This way the code is easier to read and more aligned with various other parts of the codebase, where `Result { ... }` is used as well.